### PR TITLE
task implement unsubscribe command with validation checks and corresp…

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -566,7 +566,23 @@ func UnsubscribeFromMailbox(db *sql.DB, username, mailboxName string) error {
 		return fmt.Errorf("username and mailbox name cannot be empty")
 	}
 
-	_, err := db.Exec(`
+	// First check if the subscription exists
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM subscriptions 
+		WHERE username = ? AND mailbox_name = ?
+	`, username, mailboxName).Scan(&count)
+	
+	if err != nil {
+		return fmt.Errorf("error checking subscription: %v", err)
+	}
+
+	if count == 0 {
+		return fmt.Errorf("subscription does not exist")
+	}
+
+	// Remove the subscription
+	_, err = db.Exec(`
 		DELETE FROM subscriptions 
 		WHERE username = ? AND mailbox_name = ?
 	`, username, mailboxName)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -955,8 +955,12 @@ func (s *IMAPServer) handleUnsubscribe(conn net.Conn, tag string, parts []string
 	// Unsubscribe from the mailbox
 	err := db.UnsubscribeFromMailbox(s.db, state.Username, mailboxName)
 	if err != nil {
-		fmt.Printf("Failed to unsubscribe from mailbox %s for user %s: %v\n", mailboxName, state.Username, err)
-		s.sendResponse(conn, fmt.Sprintf("%s NO UNSUBSCRIBE failure: server error", tag))
+		if strings.Contains(err.Error(), "subscription does not exist") {
+			s.sendResponse(conn, fmt.Sprintf("%s NO UNSUBSCRIBE failure: can't unsubscribe that name", tag))
+		} else {
+			fmt.Printf("Failed to unsubscribe from mailbox %s for user %s: %v\n", mailboxName, state.Username, err)
+			s.sendResponse(conn, fmt.Sprintf("%s NO UNSUBSCRIBE failure: server error", tag))
+		}
 		return
 	}
 


### PR DESCRIPTION
## 📌 Description

This PR is for implementing the "UNSUBSCRIBE" command and writing the test cases for that.

- Closes #40 

---

## 🔍 Changes Made

1. Implement the UNSUBSCRIBE command.
2. Write the test cases for that.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
