### PR TITLE
task implement STATUS command with support for mailbox status retriev…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,6 @@ jobs:
 
       - name: Test LSUB command
         run: go test -tags=test -v ./test/server -run "TestLsubCommand"
+
+      - name: Test STATUS command
+        run: go test -tags=test -v ./test/server -run "TestStatusCommand"

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@
 #   make test-subscribe    - Run SUBSCRIBE command tests
 #   make test-unsubscribe  - Run UNSUBSCRIBE command tests
 #   make test-lsub         - Run LSUB command tests
+#   make test-status      - Run STATUS command tests
 #   make test-commands     - Run all command tests
 #   make help              - Show all available targets
 
-.PHONY: test test-capability test-noop test-authenticate test-login test-starttls test-select test-examine test-create test-list test-list-extended test-delete test-commands test-verbose test-coverage test-race clean
+.PHONY: test test-capability test-noop test-authenticate test-login test-starttls test-select test-examine test-create test-list test-list-extended test-delete test-status test-commands test-verbose test-coverage test-race clean
 
 # Run all tests
 test:
@@ -96,11 +97,15 @@ test-unsubscribe:
 test-lsub:
 	go test -tags=test -v ./test/server -run "TestLsubCommand"
 
+# Run only STATUS-related tests
+test-status:
+	go test -tags=test -v ./test/server -run "TestStatusCommand"
+
 # Run only RENAME-related tests
 test-rename:
 	go test -tags=test -v ./test/server -run "TestRenameCommand"
 
-# Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE + LOGIN + STARTTLS + SELECT + EXAMINE + CREATE + LIST + LIST-EXTENDED + DELETE + SUBSCRIBE + UNSUBSCRIBE + LSUB + RENAME)
+# Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE + LOGIN + STARTTLS + SELECT + EXAMINE + CREATE + LIST + LIST-EXTENDED + DELETE + SUBSCRIBE + UNSUBSCRIBE + LSUB + STATUS + RENAME)
 test-commands:
 	@echo "Running CAPABILITY tests..."
 	@go test -tags=test -v ./test/server -run "TestCapabilityCommand"
@@ -134,6 +139,8 @@ test-commands:
 	@go test -tags=test -v ./test/server -run "TestUnsubscribeCommand"
 	@echo "\nRunning LSUB tests..."
 	@go test -tags=test -v ./test/server -run "TestLsubCommand"
+	@echo "\nRunning STATUS tests..."
+	@go test -tags=test -v ./test/server -run "TestStatusCommand"
 	@echo "\nRunning RENAME tests..."
 	@go test -tags=test -v ./test/server -run "TestRenameCommand"
 
@@ -214,7 +221,8 @@ help:
 	@echo "  test-subscribe         - Run SUBSCRIBE command tests only"
 	@echo "  test-unsubscribe       - Run UNSUBSCRIBE command tests only"
 	@echo "  test-lsub              - Run LSUB command tests only"
-	@echo "  test-commands          - Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE + LOGIN + STARTTLS + SELECT + EXAMINE + CREATE + LIST + LIST-EXTENDED + DELETE + SUBSCRIBE + UNSUBSCRIBE + LSUB)"
+	@echo "  test-status            - Run STATUS command tests only"
+	@echo "  test-commands          - Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE + LOGIN + STARTTLS + SELECT + EXAMINE + CREATE + LIST + LIST-EXTENDED + DELETE + SUBSCRIBE + UNSUBSCRIBE + LSUB + STATUS)"
 	@echo "  test-verbose           - Run tests with verbose output"
 	@echo "  test-coverage          - Run tests with coverage report"
 	@echo "  test-race              - Run tests with race detection"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1070,6 +1070,11 @@ func (s *IMAPServer) HandleLsub(conn net.Conn, tag string, parts []string, state
 	s.handleLsub(conn, tag, parts, state)
 }
 
+// HandleStatus exports the status handler for testing
+func (s *IMAPServer) HandleStatus(conn net.Conn, tag string, parts []string, state *models.ClientState) {
+	s.handleStatus(conn, tag, parts, state)
+}
+
 // parseQuotedString parses a quoted string argument, handling both quoted and unquoted strings
 func (s *IMAPServer) parseQuotedString(arg string) string {
 	if len(arg) == 0 {

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -116,9 +116,19 @@ func (t *TestInterface) HandleLsub(conn net.Conn, tag string, parts []string, st
 	t.server.handleLsub(conn, tag, parts, state)
 }
 
+// HandleStatus exposes the status handler for testing
+func (t *TestInterface) HandleStatus(conn net.Conn, tag string, parts []string, state *models.ClientState) {
+	t.server.handleStatus(conn, tag, parts, state)
+}
+
 // SetTLSCertificates sets custom TLS certificate paths for testing
 func (t *TestInterface) SetTLSCertificates(certPath, keyPath string) {
 	t.server.SetTLSCertificates(certPath, keyPath)
+}
+
+// GetDB exposes the database connection for testing
+func (t *TestInterface) GetDB() interface{} {
+	return t.server.db
 }
 
 // SendResponse exposes the sendResponse method for testing

--- a/test/README.md
+++ b/test/README.md
@@ -51,6 +51,7 @@ Contains all server-related tests organized by IMAP command:
 - **rename_test.go**: RENAME command - Mailbox renaming with hierarchy handling
 - **subscribe_test.go**: SUBSCRIBE/UNSUBSCRIBE commands - Subscription management
 - **lsub_test.go**: LSUB command - List subscribed mailboxes with wildcard support (13 tests)
+- **status_test.go**: STATUS command - Get mailbox status information with all data items (19 tests)
 
 #### Message Operation Tests
 - **select_test.go**: SELECT/EXAMINE commands - Mailbox selection for read-write/read-only
@@ -88,7 +89,8 @@ make test-delete            # DELETE command
 make test-rename            # RENAME command
 make test-subscribe         # SUBSCRIBE command
 make test-unsubscribe       # UNSUBSCRIBE command
-make test-lsub              # LSUB command (NEW)
+make test-lsub              # LSUB command
+make test-status            # STATUS command (NEW)
 
 # Run tests with verbose output
 make test-verbose
@@ -195,8 +197,9 @@ Tests use in-memory SQLite databases created fresh for each test to ensure isola
 | RENAME | rename_test.go | 15+ | ✅ Pass |
 | SUBSCRIBE | subscribe_test.go | 8 | ✅ Pass |
 | UNSUBSCRIBE | subscribe_test.go | 8 | ✅ Pass |
-| LSUB | lsub_test.go | **13** | ✅ Pass |
-| **Total** | | **144+** | ✅ All Pass |
+| LSUB | lsub_test.go | 13 | ✅ Pass |
+| STATUS | status_test.go | **19** | ✅ Pass |
+| **Total** | | **163+** | ✅ All Pass |
 
 ### Coverage Goals
 The test suite aims for high coverage of:
@@ -218,5 +221,5 @@ open coverage.html
 All tests run automatically on pull requests via GitHub Actions:
 - Go 1.23 environment
 - Full test suite execution
-- All commands including LSUB tested
+- All commands including LSUB and STATUS tested
 - Test failures block PR merges

--- a/test/server/status_test.go
+++ b/test/server/status_test.go
@@ -1,0 +1,669 @@
+package server_test
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go-imap/internal/db"
+	"go-imap/internal/models"
+	"go-imap/test/helpers"
+)
+
+// TestStatusCommand_Authentication tests STATUS command authentication requirements
+func TestStatusCommand_Authentication(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: false,
+	}
+
+	// Test STATUS command without authentication
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 NO Please authenticate first") {
+		t.Errorf("Expected authentication error, got: %s", response)
+	}
+}
+
+// TestStatusCommand_InvalidArguments tests STATUS command with invalid arguments
+func TestStatusCommand_InvalidArguments(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Test STATUS command with insufficient arguments (no mailbox)
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 BAD STATUS requires mailbox name and status data items") {
+		t.Errorf("Expected BAD response for insufficient arguments, got: %s", response)
+	}
+}
+
+// TestStatusCommand_NoStatusItems tests STATUS command without status data items
+func TestStatusCommand_NoStatusItems(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Test STATUS command without status items
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 BAD STATUS requires mailbox name and status data items") {
+		t.Errorf("Expected BAD response for missing status items, got: %s", response)
+	}
+}
+
+// TestStatusCommand_EmptyMailboxName tests STATUS command with empty mailbox name
+func TestStatusCommand_EmptyMailboxName(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Test STATUS command with empty mailbox name
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", `""`, "(MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 BAD Invalid mailbox name") {
+		t.Errorf("Expected BAD response for empty mailbox name, got: %s", response)
+	}
+}
+
+// TestStatusCommand_NonExistentMailbox tests STATUS command with non-existent mailbox
+func TestStatusCommand_NonExistentMailbox(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with non-existent mailbox
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "NonExistent", "(MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 NO STATUS failure: no status for that name") {
+		t.Errorf("Expected NO response for non-existent mailbox, got: %s", response)
+	}
+}
+
+// TestStatusCommand_MessagesItem tests STATUS command with MESSAGES item
+func TestStatusCommand_MessagesItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with MESSAGES item on INBOX
+	server.HandleStatus(conn, "A042", []string{"A042", "STATUS", "INBOX", "(MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.HasPrefix(statusLine, `* STATUS "INBOX" (MESSAGES`) {
+		t.Errorf("Expected STATUS response with MESSAGES, got: %s", statusLine)
+	}
+
+	// Verify MESSAGES value is present
+	if !strings.Contains(statusLine, "MESSAGES 0") {
+		t.Errorf("Expected MESSAGES 0 in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A042 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_MultipleItems tests STATUS command with multiple status items
+func TestStatusCommand_MultipleItems(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with multiple items (as per RFC 3501 example)
+	server.HandleStatus(conn, "A042", []string{"A042", "STATUS", "INBOX", "(UIDNEXT", "MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.HasPrefix(statusLine, `* STATUS "INBOX"`) {
+		t.Errorf("Expected STATUS response, got: %s", statusLine)
+	}
+
+	// Verify both UIDNEXT and MESSAGES are present
+	if !strings.Contains(statusLine, "UIDNEXT") {
+		t.Errorf("Expected UIDNEXT in response, got: %s", statusLine)
+	}
+	if !strings.Contains(statusLine, "MESSAGES") {
+		t.Errorf("Expected MESSAGES in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A042 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_AllItems tests STATUS command with all defined status items
+func TestStatusCommand_AllItems(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with all status items
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(MESSAGES", "RECENT", "UIDNEXT", "UIDVALIDITY", "UNSEEN)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.HasPrefix(statusLine, `* STATUS "INBOX"`) {
+		t.Errorf("Expected STATUS response, got: %s", statusLine)
+	}
+
+	// Verify all items are present
+	requiredItems := []string{"MESSAGES", "RECENT", "UIDNEXT", "UIDVALIDITY", "UNSEEN"}
+	for _, item := range requiredItems {
+		if !strings.Contains(statusLine, item) {
+			t.Errorf("Expected %s in response, got: %s", item, statusLine)
+		}
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_RecentItem tests STATUS command with RECENT item
+func TestStatusCommand_RecentItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with RECENT item
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(RECENT)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "RECENT") {
+		t.Errorf("Expected RECENT in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_UidnextItem tests STATUS command with UIDNEXT item
+func TestStatusCommand_UidnextItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with UIDNEXT item
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(UIDNEXT)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "UIDNEXT") {
+		t.Errorf("Expected UIDNEXT in response, got: %s", statusLine)
+	}
+
+	// UIDNEXT should be at least 1 for empty mailbox
+	if !strings.Contains(statusLine, "UIDNEXT 1") {
+		t.Errorf("Expected UIDNEXT 1 for empty mailbox, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_UidvalidityItem tests STATUS command with UIDVALIDITY item
+func TestStatusCommand_UidvalidityItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with UIDVALIDITY item
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(UIDVALIDITY)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "UIDVALIDITY") {
+		t.Errorf("Expected UIDVALIDITY in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_UnseenItem tests STATUS command with UNSEEN item
+func TestStatusCommand_UnseenItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with UNSEEN item
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(UNSEEN)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "UNSEEN") {
+		t.Errorf("Expected UNSEEN in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_QuotedMailboxName tests STATUS command with quoted mailbox name
+func TestStatusCommand_QuotedMailboxName(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists and create a mailbox
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+	db.EnsureMailboxTable(database)
+	db.CreateMailbox(database, "testuser", "Test Folder")
+
+	// Test STATUS command with quoted mailbox name
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", `"Test Folder"`, "(MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, `"Test Folder"`) {
+		t.Errorf("Expected quoted mailbox name in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_CustomMailbox tests STATUS command on a custom mailbox
+func TestStatusCommand_CustomMailbox(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists and create a mailbox
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+	db.EnsureMailboxTable(database)
+	db.CreateMailbox(database, "testuser", "Projects")
+
+	// Test STATUS command on custom mailbox
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "Projects", "(MESSAGES", "UIDNEXT)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, `"Projects"`) {
+		t.Errorf("Expected Projects in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_WithMessages tests STATUS command on a mailbox with messages
+func TestStatusCommand_WithMessages(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+	db.EnsureMailboxTable(database)
+
+	// Insert test messages into INBOX
+	tableName := db.GetUserTableName("testuser")
+	query := fmt.Sprintf(
+		"INSERT INTO %s (subject, sender, recipient, date_sent, raw_message, flags, folder) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		tableName,
+	)
+
+	// Insert 3 messages
+	for i := 1; i <= 3; i++ {
+		database.Exec(query,
+			fmt.Sprintf("Test Subject %d", i),
+			"sender@example.com",
+			"testuser@example.com",
+			"01-Jan-2024 12:00:00 +0000",
+			fmt.Sprintf("Subject: Test Subject %d\r\n\r\nTest body %d", i, i),
+			"",
+			"INBOX",
+		)
+	}
+
+	// Test STATUS command
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(MESSAGES", "UIDNEXT)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "MESSAGES 3") {
+		t.Errorf("Expected MESSAGES 3, got: %s", statusLine)
+	}
+	if !strings.Contains(statusLine, "UIDNEXT 4") {
+		t.Errorf("Expected UIDNEXT 4, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_InvalidStatusItem tests STATUS command with unknown status item
+func TestStatusCommand_InvalidStatusItem(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with invalid status item
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(INVALID)"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A001 BAD Unknown status data item") {
+		t.Errorf("Expected BAD response for invalid status item, got: %s", response)
+	}
+}
+
+// TestStatusCommand_DefaultMailboxes tests STATUS command on default mailboxes
+func TestStatusCommand_DefaultMailboxes(t *testing.T) {
+	defaultMailboxes := []string{"INBOX", "Sent", "Drafts", "Trash"}
+
+	for _, mailbox := range defaultMailboxes {
+		t.Run(mailbox, func(t *testing.T) {
+			server := helpers.SetupTestServerSimple(t)
+			conn := helpers.NewMockConn()
+			state := &models.ClientState{
+				Authenticated: true,
+				Username:      "testuser",
+			}
+
+			// Ensure user table exists
+			database := server.GetDB().(*sql.DB)
+			db.EnsureUserTable(database, "testuser")
+			db.EnsureMailboxTable(database)
+
+			// Test STATUS command
+			server.HandleStatus(conn, "A001", []string{"A001", "STATUS", mailbox, "(MESSAGES)"}, state)
+
+			response := conn.GetWrittenData()
+			lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+			// Should have 2 lines: STATUS response and completion
+			if len(lines) != 2 {
+				t.Fatalf("Expected 2 response lines for %s, got %d: %v", mailbox, len(lines), lines)
+			}
+
+			// Check untagged STATUS response
+			statusLine := lines[0]
+			if !strings.Contains(statusLine, fmt.Sprintf(`"%s"`, mailbox)) {
+				t.Errorf("Expected %s in response, got: %s", mailbox, statusLine)
+			}
+
+			// Check completion response
+			if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+				t.Errorf("Expected OK completion for %s, got: %s", mailbox, lines[1])
+			}
+		})
+	}
+}
+
+// TestStatusCommand_RFC3501Example tests the exact example from RFC 3501
+func TestStatusCommand_RFC3501Example(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists and create the mailbox
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+	db.EnsureMailboxTable(database)
+	db.CreateMailbox(database, "testuser", "blurdybloop")
+
+	// Test STATUS command as per RFC 3501 example: STATUS blurdybloop (UIDNEXT MESSAGES)
+	server.HandleStatus(conn, "A042", []string{"A042", "STATUS", "blurdybloop", "(UIDNEXT", "MESSAGES)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response
+	statusLine := lines[0]
+	if !strings.HasPrefix(statusLine, `* STATUS "blurdybloop"`) {
+		t.Errorf("Expected STATUS response for blurdybloop, got: %s", statusLine)
+	}
+
+	// Should contain both MESSAGES and UIDNEXT
+	if !strings.Contains(statusLine, "MESSAGES") {
+		t.Errorf("Expected MESSAGES in response, got: %s", statusLine)
+	}
+	if !strings.Contains(statusLine, "UIDNEXT") {
+		t.Errorf("Expected UIDNEXT in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A042 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}
+
+// TestStatusCommand_CaseInsensitiveItems tests STATUS command with mixed case items
+func TestStatusCommand_CaseInsensitiveItems(t *testing.T) {
+	server := helpers.SetupTestServerSimple(t)
+	conn := helpers.NewMockConn()
+	state := &models.ClientState{
+		Authenticated: true,
+		Username:      "testuser",
+	}
+
+	// Ensure user table exists
+	database := server.GetDB().(*sql.DB)
+	db.EnsureUserTable(database, "testuser")
+
+	// Test STATUS command with mixed case items
+	server.HandleStatus(conn, "A001", []string{"A001", "STATUS", "INBOX", "(messages", "UidNext)"}, state)
+
+	response := conn.GetWrittenData()
+	lines := strings.Split(strings.TrimSpace(response), "\r\n")
+
+	// Should have 2 lines: STATUS response and completion
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check untagged STATUS response - should normalize to uppercase
+	statusLine := lines[0]
+	if !strings.Contains(statusLine, "MESSAGES") {
+		t.Errorf("Expected MESSAGES in response, got: %s", statusLine)
+	}
+	if !strings.Contains(statusLine, "UIDNEXT") {
+		t.Errorf("Expected UIDNEXT in response, got: %s", statusLine)
+	}
+
+	// Check completion response
+	if !strings.Contains(lines[1], "A001 OK STATUS completed") {
+		t.Errorf("Expected OK completion, got: %s", lines[1])
+	}
+}


### PR DESCRIPTION
## 📌 Description

This PR is to implement the STAUTS command and write the test cases for that.

- Closes #48 

---

## 🔍 Changes Made

1. Implement the STATUS command
2. Write the test cases for that command.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
