### PR TITLE
refactor: move the handler_mailbox.go file and test files into seperate folder

### DIFF
--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -10,6 +10,7 @@ import (
 
 	"raven/internal/models"
 	"raven/internal/server/auth"
+	"raven/internal/server/mailbox"
 )
 
 // HandleClient handles IMAP client connections (exported for auth package)
@@ -58,15 +59,15 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "AUTHENTICATE":
 			auth.HandleAuthenticate(s, conn, tag, parts, state)
 		case "LIST":
-			s.handleList(conn, tag, parts, state)
+			mailbox.HandleList(s, conn, tag, parts, state)
 		case "LSUB":
-			s.handleLsub(conn, tag, parts, state)
+			mailbox.HandleLsub(s, conn, tag, parts, state)
 		case "CREATE":
-			s.handleCreate(conn, tag, parts, state)
+			mailbox.HandleCreate(s, conn, tag, parts, state)
 		case "DELETE":
-			s.handleDelete(conn, tag, parts, state)
+			mailbox.HandleDelete(s, conn, tag, parts, state)
 		case "RENAME":
-			s.handleRename(conn, tag, parts, state)
+			mailbox.HandleRename(s, conn, tag, parts, state)
 		case "SELECT", "EXAMINE":
 			s.handleSelect(conn, tag, parts, state)
 		case "FETCH":
@@ -78,7 +79,7 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "COPY":
 			s.handleCopy(conn, tag, parts, state)
 		case "STATUS":
-			s.handleStatus(conn, tag, parts, state)
+			mailbox.HandleStatus(s, conn, tag, parts, state)
 		case "UID":
 			s.handleUID(conn, tag, parts, state)
 		case "IDLE":
@@ -98,9 +99,9 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "EXPUNGE":
 			s.handleExpunge(conn, tag, state)
 		case "SUBSCRIBE":
-			s.handleSubscribe(conn, tag, parts, state)
+			mailbox.HandleSubscribe(s, conn, tag, parts, state)
 		case "UNSUBSCRIBE":
-			s.handleUnsubscribe(conn, tag, parts, state)
+			mailbox.HandleUnsubscribe(s, conn, tag, parts, state)
 		case "LOGOUT":
 			auth.HandleLogout(s, conn, tag)
 			return

--- a/internal/server/mailbox/handler_mailbox_create_test.go
+++ b/internal/server/mailbox/handler_mailbox_create_test.go
@@ -1,17 +1,17 @@
-package server
+package mailbox_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestCreateCommand_Unauthenticated tests CREATE command without authentication
 func TestCreateCommand_Unauthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -27,9 +27,9 @@ func TestCreateCommand_Unauthenticated(t *testing.T) {
 
 // TestCreateCommand_InvalidArguments tests CREATE command with invalid arguments
 func TestCreateCommand_InvalidArguments(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test CREATE command without mailbox name
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE"}, state)
@@ -42,9 +42,9 @@ func TestCreateCommand_InvalidArguments(t *testing.T) {
 
 // TestCreateCommand_CreateINBOX tests attempting to create INBOX
 func TestCreateCommand_CreateINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating INBOX (should fail)
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "INBOX"}, state)
@@ -57,9 +57,9 @@ func TestCreateCommand_CreateINBOX(t *testing.T) {
 
 // TestCreateCommand_CreateINBOXCaseInsensitive tests attempting to create inbox with different case
 func TestCreateCommand_CreateINBOXCaseInsensitive(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating inbox (lowercase - should fail)
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "inbox"}, state)
@@ -72,9 +72,9 @@ func TestCreateCommand_CreateINBOXCaseInsensitive(t *testing.T) {
 
 // TestCreateCommand_EmptyMailboxName tests creating mailbox with empty name
 func TestCreateCommand_EmptyMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating mailbox with empty name
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "\"\""}, state)
@@ -87,9 +87,9 @@ func TestCreateCommand_EmptyMailboxName(t *testing.T) {
 
 // TestCreateCommand_ValidMailbox tests creating a valid mailbox
 func TestCreateCommand_ValidMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating a valid mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Projects"}, state)
@@ -102,9 +102,9 @@ func TestCreateCommand_ValidMailbox(t *testing.T) {
 
 // TestCreateCommand_QuotedMailboxName tests creating mailbox with quoted name
 func TestCreateCommand_QuotedMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating a quoted mailbox name
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "\"My Projects\""}, state)
@@ -117,9 +117,9 @@ func TestCreateCommand_QuotedMailboxName(t *testing.T) {
 
 // TestCreateCommand_DuplicateMailbox tests creating the same mailbox twice
 func TestCreateCommand_DuplicateMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create mailbox first time
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "TestDupe"}, state)
@@ -141,9 +141,9 @@ func TestCreateCommand_DuplicateMailbox(t *testing.T) {
 
 // TestCreateCommand_DefaultMailboxes tests attempting to create default mailboxes
 func TestCreateCommand_DefaultMailboxes(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	defaultMailboxes := []string{"Sent", "Drafts", "Trash"}
 
@@ -159,9 +159,9 @@ func TestCreateCommand_DefaultMailboxes(t *testing.T) {
 
 // TestCreateCommand_HierarchicalMailbox tests creating hierarchical mailboxes
 func TestCreateCommand_HierarchicalMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating hierarchical mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Projects/Work/Important"}, state)
@@ -174,9 +174,9 @@ func TestCreateCommand_HierarchicalMailbox(t *testing.T) {
 
 // TestCreateCommand_TrailingHierarchySeparator tests creating mailbox with trailing separator
 func TestCreateCommand_TrailingHierarchySeparator(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test creating mailbox with trailing hierarchy separator
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Projects/"}, state)
@@ -198,9 +198,9 @@ func TestCreateCommand_TrailingHierarchySeparator(t *testing.T) {
 
 // TestCreateCommand_ListShowsCreatedMailbox tests that LIST shows newly created mailboxes
 func TestCreateCommand_ListShowsCreatedMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a new mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "NewMailbox"}, state)
@@ -228,12 +228,12 @@ func TestCreateCommand_ListShowsCreatedMailbox(t *testing.T) {
 
 // TestCreateCommand_MultipleUsers tests that mailboxes are user-specific
 func TestCreateCommand_MultipleUsers(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+
 	// User 1 creates a mailbox
-	state1 := SetupAuthenticatedState(t, srv, "user1")
-	
+	state1 := server.SetupAuthenticatedState(t, srv, "user1")
+
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "User1Mailbox"}, state1)
 	response1 := conn.GetWrittenData()
 	if !strings.Contains(response1, "A001 OK CREATE completed") {
@@ -244,8 +244,8 @@ func TestCreateCommand_MultipleUsers(t *testing.T) {
 	conn.ClearWriteBuffer()
 
 	// User 2 should be able to create a mailbox with the same name
-	state2 := SetupAuthenticatedState(t, srv, "user2")
-	
+	state2 := server.SetupAuthenticatedState(t, srv, "user2")
+
 	srv.HandleCreate(conn, "A002", []string{"A002", "CREATE", "User1Mailbox"}, state2)
 	response2 := conn.GetWrittenData()
 	if !strings.Contains(response2, "A002 OK CREATE completed") {
@@ -255,9 +255,9 @@ func TestCreateCommand_MultipleUsers(t *testing.T) {
 
 // TestCreateCommand_RFCExample tests the example from RFC 3501
 func TestCreateCommand_RFCExample(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test the RFC 3501 example: CREATE owatagusiam/
 	srv.HandleCreate(conn, "A003", []string{"A003", "CREATE", "owatagusiam/"}, state)

--- a/internal/server/mailbox/handler_mailbox_delete_test.go
+++ b/internal/server/mailbox/handler_mailbox_delete_test.go
@@ -1,17 +1,17 @@
-package server
+package mailbox_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestDeleteCommand_Unauthenticated tests DELETE command without authentication
 func TestDeleteCommand_Unauthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -27,9 +27,9 @@ func TestDeleteCommand_Unauthenticated(t *testing.T) {
 
 // TestDeleteCommand_InvalidArguments tests DELETE command with invalid arguments
 func TestDeleteCommand_InvalidArguments(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test DELETE command without mailbox name
 	srv.HandleDelete(conn, "A001", []string{"A001", "DELETE"}, state)
@@ -42,9 +42,9 @@ func TestDeleteCommand_InvalidArguments(t *testing.T) {
 
 // TestDeleteCommand_DeleteINBOX tests attempting to delete INBOX
 func TestDeleteCommand_DeleteINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test deleting INBOX (should fail)
 	srv.HandleDelete(conn, "A001", []string{"A001", "DELETE", "INBOX"}, state)
@@ -57,9 +57,9 @@ func TestDeleteCommand_DeleteINBOX(t *testing.T) {
 
 // TestDeleteCommand_DeleteINBOXCaseInsensitive tests attempting to delete inbox with different case
 func TestDeleteCommand_DeleteINBOXCaseInsensitive(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test deleting inbox (lowercase - should fail)
 	srv.HandleDelete(conn, "A001", []string{"A001", "DELETE", "inbox"}, state)
@@ -72,9 +72,9 @@ func TestDeleteCommand_DeleteINBOXCaseInsensitive(t *testing.T) {
 
 // TestDeleteCommand_EmptyMailboxName tests deleting mailbox with empty name
 func TestDeleteCommand_EmptyMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test deleting mailbox with empty name
 	srv.HandleDelete(conn, "A001", []string{"A001", "DELETE", "\"\""}, state)
@@ -87,9 +87,9 @@ func TestDeleteCommand_EmptyMailboxName(t *testing.T) {
 
 // TestDeleteCommand_NonExistentMailbox tests deleting a mailbox that doesn't exist
 func TestDeleteCommand_NonExistentMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test deleting a non-existent mailbox
 	srv.HandleDelete(conn, "A001", []string{"A001", "DELETE", "NonExistent"}, state)
@@ -102,9 +102,9 @@ func TestDeleteCommand_NonExistentMailbox(t *testing.T) {
 
 // TestDeleteCommand_ValidMailbox tests deleting a valid mailbox
 func TestDeleteCommand_ValidMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// First create a mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "TestDelete"}, state)
@@ -126,9 +126,9 @@ func TestDeleteCommand_ValidMailbox(t *testing.T) {
 
 // TestDeleteCommand_QuotedMailboxName tests deleting mailbox with quoted name
 func TestDeleteCommand_QuotedMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a mailbox with quoted name
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "\"My Projects\""}, state)
@@ -150,9 +150,9 @@ func TestDeleteCommand_QuotedMailboxName(t *testing.T) {
 
 // TestDeleteCommand_HierarchicalMailboxWithInferior tests deleting a mailbox that has inferior hierarchical names
 func TestDeleteCommand_HierarchicalMailboxWithInferior(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create parent and child mailboxes
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Projects"}, state)
@@ -170,9 +170,9 @@ func TestDeleteCommand_HierarchicalMailboxWithInferior(t *testing.T) {
 
 // TestDeleteCommand_HierarchicalMailboxChild tests deleting a child mailbox
 func TestDeleteCommand_HierarchicalMailboxChild(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create parent and child mailboxes
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Projects"}, state)
@@ -190,9 +190,9 @@ func TestDeleteCommand_HierarchicalMailboxChild(t *testing.T) {
 
 // TestDeleteCommand_RFCExample tests the examples from RFC 3501
 func TestDeleteCommand_RFCExample(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create mailboxes as per RFC example
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "blurdybloop"}, state)
@@ -242,11 +242,11 @@ func TestDeleteCommand_RFCExample(t *testing.T) {
 
 // TestDeleteCommand_MultipleUsers tests that deletion is user-specific
 func TestDeleteCommand_MultipleUsers(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// User 1 creates and deletes a mailbox
-	state1 := SetupAuthenticatedState(t, srv, "user1")
+	state1 := server.SetupAuthenticatedState(t, srv, "user1")
 
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "UserSpecific"}, state1)
 	conn.ClearWriteBuffer()
@@ -260,7 +260,7 @@ func TestDeleteCommand_MultipleUsers(t *testing.T) {
 	conn.ClearWriteBuffer()
 
 	// User 2 should not be affected - trying to delete same named mailbox should fail
-	state2 := SetupAuthenticatedState(t, srv, "user2")
+	state2 := server.SetupAuthenticatedState(t, srv, "user2")
 
 	srv.HandleDelete(conn, "A003", []string{"A003", "DELETE", "UserSpecific"}, state2)
 	response2 := conn.GetWrittenData()
@@ -271,9 +271,9 @@ func TestDeleteCommand_MultipleUsers(t *testing.T) {
 
 // TestDeleteCommand_ListVerification tests that deleted mailbox no longer appears in LIST
 func TestDeleteCommand_ListVerification(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "ToBeDeleted"}, state)
@@ -309,9 +309,9 @@ func TestDeleteCommand_ListVerification(t *testing.T) {
 
 // TestDeleteCommand_DefaultMailboxes tests attempting to delete default mailboxes
 func TestDeleteCommand_DefaultMailboxes(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Default mailboxes that should not be deletable (except INBOX which has special handling)
 	defaultMailboxes := []string{"Sent", "Drafts", "Trash"}

--- a/internal/server/mailbox/handler_mailbox_list_extended_test.go
+++ b/internal/server/mailbox/handler_mailbox_list_extended_test.go
@@ -1,4 +1,4 @@
-package server
+package mailbox_test
 
 import (
 	"fmt"
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestListCommand_RFC3501_Examples tests examples from RFC 3501 Section 6.3.8
 func TestListCommand_RFC3501_Examples(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		name              string
@@ -78,9 +78,9 @@ func TestListCommand_RFC3501_Examples(t *testing.T) {
 
 // TestListCommand_WildcardEdgeCases tests edge cases with wildcard patterns
 func TestListCommand_WildcardEdgeCases(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		pattern          string
@@ -162,9 +162,9 @@ func TestListCommand_WildcardEdgeCases(t *testing.T) {
 
 // TestListCommand_HierarchyDelimiterVariations tests various hierarchy delimiter scenarios
 func TestListCommand_HierarchyDelimiterVariations(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		reference         string
@@ -208,9 +208,9 @@ func TestListCommand_HierarchyDelimiterVariations(t *testing.T) {
 
 // TestListCommand_ReferencePatternCombination tests combination of reference and pattern
 func TestListCommand_ReferencePatternCombination(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		reference       string
@@ -257,8 +257,8 @@ func TestListCommand_ReferencePatternCombination(t *testing.T) {
 
 // TestListCommand_ErrorConditions tests various error conditions
 func TestListCommand_ErrorConditions(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// Test unauthenticated state
 	t.Run("Unauthenticated", func(t *testing.T) {
@@ -302,9 +302,9 @@ func TestListCommand_ErrorConditions(t *testing.T) {
 
 // TestListCommand_SpecialCharacters tests LIST with special characters in patterns
 func TestListCommand_SpecialCharacters(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		pattern     string

--- a/internal/server/mailbox/handler_mailbox_list_test.go
+++ b/internal/server/mailbox/handler_mailbox_list_test.go
@@ -1,4 +1,4 @@
-package server
+package mailbox_test
 
 import (
 	"fmt"
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestListCommand_Authentication tests LIST command authentication requirements
 func TestListCommand_Authentication(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -28,9 +28,9 @@ func TestListCommand_Authentication(t *testing.T) {
 
 // TestListCommand_InvalidArguments tests LIST command with invalid arguments
 func TestListCommand_InvalidArguments(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with insufficient arguments
 	srv.HandleList(conn, "A001", []string{"A001", "LIST"}, state)
@@ -43,9 +43,9 @@ func TestListCommand_InvalidArguments(t *testing.T) {
 
 // TestListCommand_HierarchyDelimiter tests LIST command with empty mailbox name
 func TestListCommand_HierarchyDelimiter(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with empty mailbox name to get hierarchy delimiter
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `""`, `""`}, state)
@@ -72,9 +72,9 @@ func TestListCommand_HierarchyDelimiter(t *testing.T) {
 
 // TestListCommand_HierarchyDelimiterWithReference tests LIST with reference and empty mailbox
 func TestListCommand_HierarchyDelimiterWithReference(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with reference and empty mailbox name
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `"~/Mail/"`, `""`}, state)
@@ -96,9 +96,9 @@ func TestListCommand_HierarchyDelimiterWithReference(t *testing.T) {
 
 // TestListCommand_AllMailboxes tests LIST command with wildcard to get all mailboxes
 func TestListCommand_AllMailboxes(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with * wildcard
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `""`, `"*"`}, state)
@@ -135,9 +135,9 @@ func TestListCommand_AllMailboxes(t *testing.T) {
 
 // TestListCommand_SpecificMailbox tests LIST command with specific mailbox name
 func TestListCommand_SpecificMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with specific mailbox
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `""`, `"INBOX"`}, state)
@@ -164,9 +164,9 @@ func TestListCommand_SpecificMailbox(t *testing.T) {
 
 // TestListCommand_WildcardMatching tests LIST command with various wildcard patterns
 func TestListCommand_WildcardMatching(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
 		pattern          string
@@ -231,9 +231,9 @@ func TestListCommand_WildcardMatching(t *testing.T) {
 
 // TestListCommand_PercentWildcard tests LIST command with % wildcard (no hierarchy delimiter match)
 func TestListCommand_PercentWildcard(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with % wildcard
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `""`, `"%"`}, state)
@@ -256,9 +256,9 @@ func TestListCommand_PercentWildcard(t *testing.T) {
 
 // TestListCommand_CaseInsensitiveINBOX tests that INBOX matching is case-insensitive
 func TestListCommand_CaseInsensitiveINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []string{"inbox", "Inbox", "InBoX", "INBOX"}
 
@@ -284,9 +284,9 @@ func TestListCommand_CaseInsensitiveINBOX(t *testing.T) {
 
 // TestListCommand_MailboxAttributes tests that mailboxes have correct attributes
 func TestListCommand_MailboxAttributes(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test LIST command with * wildcard to get all mailboxes
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `""`, `"*"`}, state)
@@ -311,13 +311,13 @@ func TestListCommand_MailboxAttributes(t *testing.T) {
 
 // TestListCommand_QuotedStrings tests LIST command with various quoted string formats
 func TestListCommand_QuotedStrings(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	testCases := []struct {
-		reference string
-		mailbox   string
+		reference   string
+		mailbox    string
 		description string
 	}{
 		{`""`, `"INBOX"`, "Empty reference, quoted INBOX"},
@@ -348,9 +348,9 @@ func TestListCommand_QuotedStrings(t *testing.T) {
 
 // TestListCommand_ReferenceHandling tests LIST command reference argument handling
 func TestListCommand_ReferenceHandling(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test with reference that should be prefixed to pattern
 	srv.HandleList(conn, "A001", []string{"A001", "LIST", `"Mail/"`, `"IN*"`}, state)

--- a/internal/server/mailbox/handler_mailbox_lsub_test.go
+++ b/internal/server/mailbox/handler_mailbox_lsub_test.go
@@ -1,14 +1,14 @@
 //go:build test
 // +build test
 
-package server
+package mailbox_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestLsubCommand_BasicUsage tests LSUB with basic wildcard patterns

--- a/internal/server/mailbox/handler_mailbox_rename_test.go
+++ b/internal/server/mailbox/handler_mailbox_rename_test.go
@@ -1,17 +1,17 @@
-package server
+package mailbox_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestRenameCommand_Unauthenticated tests RENAME command without authentication
 func TestRenameCommand_Unauthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -27,9 +27,9 @@ func TestRenameCommand_Unauthenticated(t *testing.T) {
 
 // TestRenameCommand_InvalidArguments tests RENAME command with invalid arguments
 func TestRenameCommand_InvalidArguments(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test RENAME command without enough arguments
 	srv.HandleRename(conn, "A001", []string{"A001", "RENAME", "oldbox"}, state)
@@ -42,9 +42,9 @@ func TestRenameCommand_InvalidArguments(t *testing.T) {
 
 // TestRenameCommand_EmptyMailboxNames tests RENAME command with empty mailbox names
 func TestRenameCommand_EmptyMailboxNames(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test RENAME command with empty old name
 	srv.HandleRename(conn, "A001", []string{"A001", "RENAME", "\"\"", "newbox"}, state)
@@ -66,9 +66,9 @@ func TestRenameCommand_EmptyMailboxNames(t *testing.T) {
 
 // TestRenameCommand_NonExistentMailbox tests renaming a non-existent mailbox
 func TestRenameCommand_NonExistentMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test renaming a non-existent mailbox
 	srv.HandleRename(conn, "A001", []string{"A001", "RENAME", "NonExistent", "NewName"}, state)
@@ -81,9 +81,9 @@ func TestRenameCommand_NonExistentMailbox(t *testing.T) {
 
 // TestRenameCommand_RenameToExistingMailbox tests renaming to an existing mailbox
 func TestRenameCommand_RenameToExistingMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create source and destination mailboxes
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "SourceBox"}, state)
@@ -103,9 +103,9 @@ func TestRenameCommand_RenameToExistingMailbox(t *testing.T) {
 
 // TestRenameCommand_RenameToINBOX tests renaming to INBOX
 func TestRenameCommand_RenameToINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a source mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "SourceBox"}, state)
@@ -124,9 +124,9 @@ func TestRenameCommand_RenameToINBOX(t *testing.T) {
 
 // TestRenameCommand_RenameINBOX tests renaming INBOX (special case)
 func TestRenameCommand_RenameINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Rename INBOX to a new name
 	srv.HandleRename(conn, "A001", []string{"A001", "RENAME", "INBOX", "old-mail"}, state)
@@ -153,9 +153,9 @@ func TestRenameCommand_RenameINBOX(t *testing.T) {
 
 // TestRenameCommand_ValidRename tests successful mailbox renaming
 func TestRenameCommand_ValidRename(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a source mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "OldName"}, state)
@@ -187,9 +187,9 @@ func TestRenameCommand_ValidRename(t *testing.T) {
 
 // TestRenameCommand_HierarchicalRename tests renaming with hierarchical names
 func TestRenameCommand_HierarchicalRename(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create hierarchical mailboxes
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "foo"}, state)
@@ -235,9 +235,9 @@ func TestRenameCommand_HierarchicalRename(t *testing.T) {
 
 // TestRenameCommand_CreateSuperiorHierarchy tests creating superior hierarchy during rename
 func TestRenameCommand_CreateSuperiorHierarchy(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a simple mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "simple"}, state)
@@ -280,9 +280,9 @@ func TestRenameCommand_CreateSuperiorHierarchy(t *testing.T) {
 
 // TestRenameCommand_QuotedNames tests renaming with quoted mailbox names
 func TestRenameCommand_QuotedNames(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a mailbox with quoted name
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "\"My Old Box\""}, state)
@@ -310,9 +310,9 @@ func TestRenameCommand_QuotedNames(t *testing.T) {
 
 // TestRenameCommand_CaseInsensitiveINBOX tests INBOX renaming is case-insensitive
 func TestRenameCommand_CaseInsensitiveINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Rename inbox (lowercase) to a new name
 	srv.HandleRename(conn, "A001", []string{"A001", "RENAME", "inbox", "old-inbox"}, state)
@@ -334,9 +334,9 @@ func TestRenameCommand_CaseInsensitiveINBOX(t *testing.T) {
 
 // TestRenameCommand_Multiple tests multiple rename operations
 func TestRenameCommand_Multiple(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create multiple mailboxes
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "Box1"}, state)
@@ -381,9 +381,9 @@ func TestRenameCommand_Multiple(t *testing.T) {
 
 // TestRenameCommand_ErrorRecovery tests error recovery after failed renames
 func TestRenameCommand_ErrorRecovery(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Create a mailbox
 	srv.HandleCreate(conn, "A001", []string{"A001", "CREATE", "TestBox"}, state)

--- a/internal/server/mailbox/handler_mailbox_status_test.go
+++ b/internal/server/mailbox/handler_mailbox_status_test.go
@@ -1,7 +1,7 @@
 //go:build test
 // +build test
 
-package server
+package mailbox_test
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestStatusCommand_Authentication tests STATUS command authentication requirements

--- a/internal/server/mailbox/handler_mailbox_subscribe_test.go
+++ b/internal/server/mailbox/handler_mailbox_subscribe_test.go
@@ -1,18 +1,18 @@
-package server
+package mailbox_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+	"raven/internal/server"
 )
 
 // TestSubscribeCommand_ValidMailbox tests SUBSCRIBE command with valid mailbox
 func TestSubscribeCommand_ValidMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test SUBSCRIBE command
 	srv.HandleSubscribe(conn, "A001", []string{"A001", "SUBSCRIBE", "TestFolder"}, state)
@@ -27,9 +27,9 @@ func TestSubscribeCommand_ValidMailbox(t *testing.T) {
 
 // TestSubscribeCommand_QuotedMailbox tests SUBSCRIBE command with quoted mailbox name
 func TestSubscribeCommand_QuotedMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test SUBSCRIBE command with quoted mailbox
 	srv.HandleSubscribe(conn, "A002", []string{"A002", "SUBSCRIBE", "\"Test Folder\""}, state)
@@ -44,9 +44,9 @@ func TestSubscribeCommand_QuotedMailbox(t *testing.T) {
 
 // TestSubscribeCommand_INBOXMailbox tests SUBSCRIBE command with INBOX
 func TestSubscribeCommand_INBOXMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test SUBSCRIBE command with INBOX
 	srv.HandleSubscribe(conn, "A003", []string{"A003", "SUBSCRIBE", "INBOX"}, state)
@@ -61,8 +61,8 @@ func TestSubscribeCommand_INBOXMailbox(t *testing.T) {
 
 // TestSubscribeCommand_NotAuthenticated tests SUBSCRIBE command without authentication
 func TestSubscribeCommand_NotAuthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -80,9 +80,9 @@ func TestSubscribeCommand_NotAuthenticated(t *testing.T) {
 
 // TestSubscribeCommand_MissingArgument tests SUBSCRIBE command without mailbox argument
 func TestSubscribeCommand_MissingArgument(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test SUBSCRIBE command without mailbox argument
 	srv.HandleSubscribe(conn, "A005", []string{"A005", "SUBSCRIBE"}, state)
@@ -97,9 +97,9 @@ func TestSubscribeCommand_MissingArgument(t *testing.T) {
 
 // TestSubscribeCommand_EmptyMailboxName tests SUBSCRIBE command with empty mailbox name
 func TestSubscribeCommand_EmptyMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test SUBSCRIBE command with empty mailbox name
 	srv.HandleSubscribe(conn, "A006", []string{"A006", "SUBSCRIBE", ""}, state)
@@ -114,9 +114,9 @@ func TestSubscribeCommand_EmptyMailboxName(t *testing.T) {
 
 // TestUnsubscribeCommand_ValidMailbox tests UNSUBSCRIBE command with valid mailbox
 func TestUnsubscribeCommand_ValidMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// First subscribe to a mailbox
 	srv.HandleSubscribe(conn, "A001", []string{"A001", "SUBSCRIBE", "TestFolder"}, state)
@@ -135,8 +135,8 @@ func TestUnsubscribeCommand_ValidMailbox(t *testing.T) {
 
 // TestUnsubscribeCommand_NotAuthenticated tests UNSUBSCRIBE command without authentication
 func TestUnsubscribeCommand_NotAuthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -154,9 +154,9 @@ func TestUnsubscribeCommand_NotAuthenticated(t *testing.T) {
 
 // TestUnsubscribeCommand_MissingArgument tests UNSUBSCRIBE command without mailbox argument
 func TestUnsubscribeCommand_MissingArgument(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test UNSUBSCRIBE command without mailbox argument
 	srv.HandleUnsubscribe(conn, "A004", []string{"A004", "UNSUBSCRIBE"}, state)
@@ -171,9 +171,9 @@ func TestUnsubscribeCommand_MissingArgument(t *testing.T) {
 
 // TestUnsubscribeCommand_EmptyMailboxName tests UNSUBSCRIBE command with empty mailbox name
 func TestUnsubscribeCommand_EmptyMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test UNSUBSCRIBE command with empty mailbox name
 	srv.HandleUnsubscribe(conn, "A005", []string{"A005", "UNSUBSCRIBE", ""}, state)
@@ -188,9 +188,9 @@ func TestUnsubscribeCommand_EmptyMailboxName(t *testing.T) {
 
 // TestUnsubscribeCommand_QuotedMailbox tests UNSUBSCRIBE command with quoted mailbox name
 func TestUnsubscribeCommand_QuotedMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// First subscribe to a quoted mailbox
 	srv.HandleSubscribe(conn, "A001", []string{"A001", "SUBSCRIBE", "\"Test Folder\""}, state)
@@ -209,9 +209,9 @@ func TestUnsubscribeCommand_QuotedMailbox(t *testing.T) {
 
 // TestUnsubscribeCommand_NonSubscribed tests UNSUBSCRIBE command with mailbox that was never subscribed
 func TestUnsubscribeCommand_NonSubscribed(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test UNSUBSCRIBE command on a mailbox that was never subscribed
 	srv.HandleUnsubscribe(conn, "A007", []string{"A007", "UNSUBSCRIBE", "NonExistentFolder"}, state)
@@ -226,9 +226,9 @@ func TestUnsubscribeCommand_NonSubscribed(t *testing.T) {
 
 // TestUnsubscribeCommand_ExampleFromRFC tests the exact example from RFC 3501
 func TestUnsubscribeCommand_ExampleFromRFC(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// First subscribe to the RFC example mailbox
 	srv.HandleSubscribe(conn, "A001", []string{"A001", "SUBSCRIBE", "#news.comp.mail.mime"}, state)
@@ -248,9 +248,9 @@ func TestUnsubscribeCommand_ExampleFromRFC(t *testing.T) {
 
 // TestSubscribeCommand_ExampleFromRFC tests the exact example from RFC 3501
 func TestSubscribeCommand_ExampleFromRFC(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Test the RFC example: C: A002 SUBSCRIBE #news.comp.mail.mime
 	srv.HandleSubscribe(conn, "A002", []string{"A002", "SUBSCRIBE", "#news.comp.mail.mime"}, state)
@@ -265,9 +265,9 @@ func TestSubscribeCommand_ExampleFromRFC(t *testing.T) {
 
 // TestSubscribeCommand_DuplicateSubscription tests subscribing to the same mailbox twice
 func TestSubscribeCommand_DuplicateSubscription(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv, "testuser")
 
 	// Subscribe to a mailbox twice
 	srv.HandleSubscribe(conn, "A001", []string{"A001", "SUBSCRIBE", "TestFolder"}, state)

--- a/internal/server/testing_interface.go
+++ b/internal/server/testing_interface.go
@@ -5,6 +5,7 @@ import (
 
 	"raven/internal/models"
 	"raven/internal/server/auth"
+	"raven/internal/server/mailbox"
 )
 
 // TestInterface provides access to internal methods for testing
@@ -31,22 +32,22 @@ func (t *TestInterface) HandleLogin(conn net.Conn, tag string, parts []string, s
 
 // HandleList exposes the list handler for testing
 func (t *TestInterface) HandleList(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleList(conn, tag, parts, state)
+	mailbox.HandleList(t.server, conn, tag, parts, state)
 }
 
 // HandleCreate exposes the create handler for testing
 func (t *TestInterface) HandleCreate(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleCreate(conn, tag, parts, state)
+	mailbox.HandleCreate(t.server, conn, tag, parts, state)
 }
 
 // HandleDelete exposes the delete handler for testing
 func (t *TestInterface) HandleDelete(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleDelete(conn, tag, parts, state)
+	mailbox.HandleDelete(t.server, conn, tag, parts, state)
 }
 
 // HandleRename exposes the rename handler for testing
 func (t *TestInterface) HandleRename(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleRename(conn, tag, parts, state)
+	mailbox.HandleRename(t.server, conn, tag, parts, state)
 }
 
 // HandleLogout exposes the logout handler for testing
@@ -119,22 +120,22 @@ func (t *TestInterface) HandleStartTLS(conn net.Conn, tag string, parts []string
 
 // HandleSubscribe exposes the subscribe handler for testing
 func (t *TestInterface) HandleSubscribe(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleSubscribe(conn, tag, parts, state)
+	mailbox.HandleSubscribe(t.server, conn, tag, parts, state)
 }
 
 // HandleUnsubscribe exposes the unsubscribe handler for testing
 func (t *TestInterface) HandleUnsubscribe(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleUnsubscribe(conn, tag, parts, state)
+	mailbox.HandleUnsubscribe(t.server, conn, tag, parts, state)
 }
 
 // HandleLsub exposes the lsub handler for testing
 func (t *TestInterface) HandleLsub(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleLsub(conn, tag, parts, state)
+	mailbox.HandleLsub(t.server, conn, tag, parts, state)
 }
 
 // HandleStatus exposes the status handler for testing
 func (t *TestInterface) HandleStatus(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleStatus(conn, tag, parts, state)
+	mailbox.HandleStatus(t.server, conn, tag, parts, state)
 }
 
 // HandleSearch exposes the search handler for testing


### PR DESCRIPTION
## 📌 Description

This PR is to move handler_mailbox.go file into seperate folder with it's test files.

- Closes #102 

---

## 🔍 Changes Made

- Move handler_message.go file and it's test files into seperate folder.
- Fix the all related issues after moving into seperate folder.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
