### PR TITLE
Refactor: move NOOP, IDLE, and NAMESPACE handlers to extension package

### DIFF
--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -10,6 +10,7 @@ import (
 
 	"raven/internal/models"
 	"raven/internal/server/auth"
+	"raven/internal/server/extension"
 	"raven/internal/server/mailbox"
 	"raven/internal/server/message"
 )
@@ -84,15 +85,15 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "UID":
 			s.handleUID(conn, tag, parts, state)
 		case "IDLE":
-			s.handleIdle(conn, tag, state)
+			extension.HandleIdle(s, conn, tag, state)
 		case "NAMESPACE":
-			s.handleNamespace(conn, tag, state)
+			extension.HandleNamespace(s, conn, tag, state)
 		case "UNSELECT":
 			s.handleUnselect(conn, tag, state)
 		case "APPEND":
 			message.HandleAppendWithReader(s, reader, conn, tag, parts, line, state)
 		case "NOOP":
-			s.handleNoop(conn, tag, state)
+			extension.HandleNoop(s, conn, tag, state)
 		case "CHECK":
 			message.HandleCheck(s, conn, tag, state)
 		case "CLOSE":

--- a/internal/server/extension/handler_extension_noop_test.go
+++ b/internal/server/extension/handler_extension_noop_test.go
@@ -1,14 +1,14 @@
 //go:build test
 // +build test
 
-package server
+package extension
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+
 )
 
 // TestNoopCommand_Unauthenticated tests NOOP before authentication

--- a/internal/server/testing_interface.go
+++ b/internal/server/testing_interface.go
@@ -5,6 +5,7 @@ import (
 
 	"raven/internal/models"
 	"raven/internal/server/auth"
+	"raven/internal/server/extension"
 	"raven/internal/server/mailbox"
 	"raven/internal/server/message"
 )
@@ -58,12 +59,12 @@ func (t *TestInterface) HandleLogout(conn net.Conn, tag string) {
 
 // HandleIdle exposes the idle handler for testing
 func (t *TestInterface) HandleIdle(conn net.Conn, tag string, state *models.ClientState) {
-	t.server.handleIdle(conn, tag, state)
+	extension.HandleIdle(t.server, conn, tag, state)
 }
 
 // HandleNamespace exposes the namespace handler for testing
 func (t *TestInterface) HandleNamespace(conn net.Conn, tag string, state *models.ClientState) {
-	t.server.handleNamespace(conn, tag, state)
+	extension.HandleNamespace(t.server, conn, tag, state)
 }
 
 // HandleUnselect exposes the unselect handler for testing
@@ -73,7 +74,7 @@ func (t *TestInterface) HandleUnselect(conn net.Conn, tag string, state *models.
 
 // HandleNoop exposes the noop handler for testing
 func (t *TestInterface) HandleNoop(conn net.Conn, tag string, state *models.ClientState) {
-	t.server.handleNoop(conn, tag, state)
+	extension.HandleNoop(t.server, conn, tag, state)
 }
 
 // HandleCheck exposes the check handler for testing


### PR DESCRIPTION
## 📌 Description

This PR is to move handler_extension.go file into a separate extension folder with its tests for better maintainability

- Closes #105 

---

## 🔍 Changes Made

- Move the handler_extension.go file into a separate folder
- Move test files into their folder.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->
N/A
---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
N/A
