### PR TITLE
refactor: handler_selection.go and its test files are moved

### DIFF
--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -13,6 +13,7 @@ import (
 	"raven/internal/server/extension"
 	"raven/internal/server/mailbox"
 	"raven/internal/server/message"
+	"raven/internal/server/selection"
 )
 
 // HandleClient handles IMAP client connections (exported for auth package)
@@ -71,7 +72,7 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "RENAME":
 			mailbox.HandleRename(s, conn, tag, parts, state)
 		case "SELECT", "EXAMINE":
-			s.handleSelect(conn, tag, parts, state)
+			selection.HandleSelect(s, conn, tag, parts, state)
 		case "FETCH":
 			message.HandleFetch(s, conn, tag, parts, state)
 		case "SEARCH":
@@ -89,7 +90,7 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "NAMESPACE":
 			extension.HandleNamespace(s, conn, tag, state)
 		case "UNSELECT":
-			s.handleUnselect(conn, tag, state)
+			selection.HandleUnselect(s, conn, tag, state)
 		case "APPEND":
 			message.HandleAppendWithReader(s, reader, conn, tag, parts, line, state)
 		case "NOOP":
@@ -97,7 +98,7 @@ func handleClient(s *IMAPServer, conn net.Conn, state *models.ClientState) {
 		case "CHECK":
 			message.HandleCheck(s, conn, tag, state)
 		case "CLOSE":
-			s.handleClose(conn, tag, state)
+			selection.HandleClose(s, conn, tag, state)
 		case "EXPUNGE":
 			message.HandleExpunge(s, conn, tag, state)
 		case "SUBSCRIBE":

--- a/internal/server/selection/handler_selection_close_test.go
+++ b/internal/server/selection/handler_selection_close_test.go
@@ -1,14 +1,14 @@
 //go:build test
 // +build test
 
-package server
+package selection
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
-	
+
 )
 
 // TestCloseCommand_Unauthenticated tests CLOSE before authentication

--- a/internal/server/selection/handler_selection_select_test.go
+++ b/internal/server/selection/handler_selection_select_test.go
@@ -1,7 +1,7 @@
 //go:build test
 // +build test
 
-package server
+package selection
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"raven/internal/models"
-	
+
 )
 
 // TestSelectCommand_BasicFlow tests the basic SELECT command with an existing mailbox

--- a/internal/server/testing_interface.go
+++ b/internal/server/testing_interface.go
@@ -8,6 +8,7 @@ import (
 	"raven/internal/server/extension"
 	"raven/internal/server/mailbox"
 	"raven/internal/server/message"
+	"raven/internal/server/selection"
 )
 
 // TestInterface provides access to internal methods for testing
@@ -69,7 +70,7 @@ func (t *TestInterface) HandleNamespace(conn net.Conn, tag string, state *models
 
 // HandleUnselect exposes the unselect handler for testing
 func (t *TestInterface) HandleUnselect(conn net.Conn, tag string, state *models.ClientState) {
-	t.server.handleUnselect(conn, tag, state)
+	selection.HandleUnselect(t.server, conn, tag, state)
 }
 
 // HandleNoop exposes the noop handler for testing
@@ -84,7 +85,7 @@ func (t *TestInterface) HandleCheck(conn net.Conn, tag string, state *models.Cli
 
 // HandleClose exposes the close handler for testing
 func (t *TestInterface) HandleClose(conn net.Conn, tag string, state *models.ClientState) {
-	t.server.handleClose(conn, tag, state)
+	selection.HandleClose(t.server, conn, tag, state)
 }
 
 // HandleExpunge exposes the expunge handler for testing
@@ -94,12 +95,12 @@ func (t *TestInterface) HandleExpunge(conn net.Conn, tag string, state *models.C
 
 // HandleSelect exposes the select handler for testing
 func (t *TestInterface) HandleSelect(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleSelect(conn, tag, parts, state)
+	selection.HandleSelect(t.server, conn, tag, parts, state)
 }
 
 // HandleExamine exposes the examine handler for testing (uses same handler as SELECT)
 func (t *TestInterface) HandleExamine(conn net.Conn, tag string, parts []string, state *models.ClientState) {
-	t.server.handleSelect(conn, tag, parts, state)
+	selection.HandleSelect(t.server, conn, tag, parts, state)
 }
 
 // HandleAppend exposes the append handler for testing


### PR DESCRIPTION
## 📌 Description

This PR is to move handler_selection.go the file and its test files into a separate folder. 

- Closes #107 

---

## 🔍 Changes Made

- Move the handler_selection.go file into a separate folder
- Move the test files into the same folder.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
