### PR TITLE
feat: add explicit TLS handshake in HandleStartTLS and HandleSSLConne…

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -142,6 +142,9 @@ func (s *IMAPServer) ExtractUsername(email string) string {
 // HandleSSLConnection handles SSL/TLS connections (delegates to auth package)
 func (s *IMAPServer) HandleSSLConnection(conn net.Conn) {
 	clientHandler := func(conn net.Conn, state *models.ClientState) {
+		// Send greeting for SSL/TLS connections
+		// TLS is active, so AUTH=PLAIN and LOGIN are allowed (no STARTTLS needed)
+		s.sendResponse(conn, "* OK [CAPABILITY IMAP4rev1 AUTH=PLAIN LOGIN UIDPLUS IDLE LITERAL+] SQLite IMAP server ready")
 		handleClient(s, conn, state)
 	}
 	auth.HandleSSLConnection(clientHandler, conn)


### PR DESCRIPTION
## 📌 Description

This PR is to resolve the issue that port 993 was not automatically loaded when we connected to Mail User Agent. 

- Closes #77 

---

## 🔍 Changes Made

- Explicitly perform TLS handshake
- Send greeting for SSL/TLS connections(Major fix for the above bug)

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
