### PR TITLE
test: improve the unit test coverage in message folder

### DIFF
--- a/internal/server/message/handler_message_additional_test.go
+++ b/internal/server/message/handler_message_additional_test.go
@@ -1,0 +1,851 @@
+//go:build test
+
+package message_test
+
+import (
+	"strings"
+	"testing"
+
+	"raven/internal/models"
+	"raven/internal/server"
+)
+
+// ============================================================================
+// Advanced SEARCH Tests - Cover search helper functions
+// ============================================================================
+
+// TestSearchCommand_HeaderExists tests SEARCH with HEADER
+func TestSearchCommand_HeaderExists(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH HEADER
+	srv.HandleSearch(conn, "S001", []string{"S001", "SEARCH", "HEADER", "Subject", "Test"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S001 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_LargerSize tests SEARCH LARGER
+func TestSearchCommand_LargerSize(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH LARGER
+	srv.HandleSearch(conn, "S002", []string{"S002", "SEARCH", "LARGER", "10"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S002 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_SmallerSize tests SEARCH SMALLER
+func TestSearchCommand_SmallerSize(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SMALLER
+	srv.HandleSearch(conn, "S003", []string{"S003", "SEARCH", "SMALLER", "999999"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S003 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_BeforeDate tests SEARCH BEFORE
+func TestSearchCommand_BeforeDate(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH BEFORE
+	srv.HandleSearch(conn, "S004", []string{"S004", "SEARCH", "BEFORE", "31-Dec-2099"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S004 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_OnDate tests SEARCH ON
+func TestSearchCommand_OnDate(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH ON (today's date)
+	srv.HandleSearch(conn, "S005", []string{"S005", "SEARCH", "ON", "24-Nov-2025"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S005 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_SinceDate tests SEARCH SINCE
+func TestSearchCommand_SinceDate(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SINCE
+	srv.HandleSearch(conn, "S006", []string{"S006", "SEARCH", "SINCE", "1-Jan-2020"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S006 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_SentBefore tests SEARCH SENTBEFORE
+func TestSearchCommand_SentBefore(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SENTBEFORE
+	srv.HandleSearch(conn, "S007", []string{"S007", "SEARCH", "SENTBEFORE", "31-Dec-2099"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S007 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_SentOn tests SEARCH SENTON
+func TestSearchCommand_SentOn(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SENTON
+	srv.HandleSearch(conn, "S008", []string{"S008", "SEARCH", "SENTON", "24-Nov-2025"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S008 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_SentSince tests SEARCH SENTSINCE
+func TestSearchCommand_SentSince(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SENTSINCE
+	srv.HandleSearch(conn, "S009", []string{"S009", "SEARCH", "SENTSINCE", "1-Jan-2020"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S009 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_TextSearch tests SEARCH TEXT
+func TestSearchCommand_TextSearch(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH TEXT
+	srv.HandleSearch(conn, "S010", []string{"S010", "SEARCH", "TEXT", "Test"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S010 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_BodySearch tests SEARCH BODY
+func TestSearchCommand_BodySearch(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH BODY
+	srv.HandleSearch(conn, "S011", []string{"S011", "SEARCH", "BODY", "test"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S011 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_NotCriteria tests SEARCH NOT
+func TestSearchCommand_NotCriteria(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH NOT DELETED
+	srv.HandleSearch(conn, "S012", []string{"S012", "SEARCH", "NOT", "DELETED"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S012 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_OrCriteria tests SEARCH OR
+func TestSearchCommand_OrCriteria(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH OR SEEN DELETED
+	srv.HandleSearch(conn, "S013", []string{"S013", "SEARCH", "OR", "SEEN", "DELETED"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "S013 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// ============================================================================
+// SEARCH with HEADER (tests hasHeader function)
+// ============================================================================
+
+// TestSearchCommand_HeaderWithoutValue tests SEARCH with HEADER field only (no value)
+func TestSearchCommand_HeaderWithoutValue(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH HEADER with empty value tests hasHeader function
+	srv.HandleSearch(conn, "H001", []string{"H001", "SEARCH", "HEADER", "Subject", `""`}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+	if !strings.Contains(response, "H001 OK") {
+		t.Errorf("Expected OK response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_HeaderExistence tests searching for existence of a header
+func TestSearchCommand_HeaderExistence(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH for existence of From header (empty search string)
+	srv.HandleSearch(conn, "H002", []string{"H002", "SEARCH", "HEADER", "From", `""`}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH 1") {
+		t.Errorf("Expected message to match (From header exists), got: %s", response)
+	}
+}
+
+// TestSearchCommand_NonExistentHeader tests searching for non-existent header
+func TestSearchCommand_NonExistentHeader(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH for non-existent header
+	srv.HandleSearch(conn, "H003", []string{"H003", "SEARCH", "HEADER", "X-NonExistent", `""`}, state)
+
+	response := conn.GetWrittenData()
+	// Should return empty search result
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// ============================================================================
+// Additional Coverage Tests
+// ============================================================================
+
+// TestSearchCommand_SequenceRange tests various sequence set formats
+func TestSearchCommand_SequenceRange(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test 1", "sender@test.com", "testuser@localhost", "INBOX")
+	server.InsertTestMail(t, database, "testuser", "Test 2", "sender@test.com", "testuser@localhost", "INBOX")
+	server.InsertTestMail(t, database, "testuser", "Test 3", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// Test sequence range
+	srv.HandleSearch(conn, "SEQ001", []string{"SEQ001", "SEARCH", "1:2"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_UIDSet tests UID set in SEARCH
+func TestSearchCommand_UIDSet(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test 1", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// Test UID search
+	srv.HandleSearch(conn, "UID001", []string{"UID001", "SEARCH", "UID", "1"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_Keyword tests SEARCH KEYWORD
+func TestSearchCommand_Keyword(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH KEYWORD (tests requiresArgument function)
+	srv.HandleSearch(conn, "K001", []string{"K001", "SEARCH", "KEYWORD", "test"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_UnKeyword tests SEARCH UNKEYWORD
+func TestSearchCommand_UnKeyword(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH UNKEYWORD
+	srv.HandleSearch(conn, "K002", []string{"K002", "SEARCH", "UNKEYWORD", "test"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_BCC tests SEARCH BCC
+func TestSearchCommand_BCC(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH BCC
+	srv.HandleSearch(conn, "B001", []string{"B001", "SEARCH", "BCC", "test@example.com"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_CC tests SEARCH CC
+func TestSearchCommand_CC(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH CC
+	srv.HandleSearch(conn, "C001", []string{"C001", "SEARCH", "CC", "test@example.com"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH") {
+		t.Errorf("Expected SEARCH response, got: %s", response)
+	}
+}
+
+// TestSearchCommand_From tests SEARCH FROM
+func TestSearchCommand_From(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH FROM
+	srv.HandleSearch(conn, "F001", []string{"F001", "SEARCH", "FROM", "sender"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH 1") {
+		t.Errorf("Expected message to match, got: %s", response)
+	}
+}
+
+// TestSearchCommand_To tests SEARCH TO
+func TestSearchCommand_To(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH TO
+	srv.HandleSearch(conn, "T001", []string{"T001", "SEARCH", "TO", "testuser"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH 1") {
+		t.Errorf("Expected message to match, got: %s", response)
+	}
+}
+
+// TestSearchCommand_Subject tests SEARCH SUBJECT
+func TestSearchCommand_Subject(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Important Message", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+		SelectedFolder:    "INBOX",
+	}
+
+	// SEARCH SUBJECT
+	srv.HandleSearch(conn, "SU001", []string{"SU001", "SEARCH", "SUBJECT", "Important"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "* SEARCH 1") {
+		t.Errorf("Expected message to match, got: %s", response)
+	}
+}
+
+// ============================================================================
+// FETCH Edge Cases - Improve coverage of processFetchForMessage
+// ============================================================================
+
+// TestFetchCommand_BodyPeekHeaderFields tests BODY.PEEK[HEADER.FIELDS (...)]
+func TestFetchCommand_BodyPeekHeaderFields(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+	}
+
+	srv.HandleFetch(conn, "F101", []string{"F101", "FETCH", "1", "BODY.PEEK[HEADER.FIELDS (FROM SUBJECT)]"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "BODY[HEADER.FIELDS") {
+		t.Errorf("Expected BODY[HEADER.FIELDS in response, got: %s", response)
+	}
+}
+
+// TestFetchCommand_BodyPartial tests BODY[]<partial>
+func TestFetchCommand_BodyPartial(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+	}
+
+	srv.HandleFetch(conn, "F102", []string{"F102", "FETCH", "1", "BODY[]<0.100>"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "BODY[]") {
+		t.Errorf("Expected BODY[] in response, got: %s", response)
+	}
+}
+
+// TestFetchCommand_BodyPart tests BODY[n] for multipart messages
+func TestFetchCommand_BodyPart(t *testing.T) {
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
+
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
+
+	state := &models.ClientState{
+		Authenticated:     true,
+		UserID:            userID,
+		Username:          "testuser",
+		SelectedMailboxID: mailboxID,
+	}
+
+	srv.HandleFetch(conn, "F103", []string{"F103", "FETCH", "1", "BODY[1]"}, state)
+
+	response := conn.GetWrittenData()
+	// May or may not have part 1, but should handle gracefully
+	if !strings.Contains(response, "F103") {
+		t.Errorf("Expected response with tag, got: %s", response)
+	}
+}

--- a/internal/server/message/handler_message_append_test.go
+++ b/internal/server/message/handler_message_append_test.go
@@ -1,6 +1,6 @@
 //go:build test
 
-package message
+package message_test
 
 import (
 	"fmt"
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"raven/internal/models"
+	"raven/internal/server"
 )
 
 // TestAppendCommand_Basic tests basic APPEND functionality
 func TestAppendCommand_Basic(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Simulate APPEND command with a simple message
 	message := "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test Message\r\n\r\nThis is a test message body.\r\n"
@@ -47,9 +48,9 @@ func TestAppendCommand_Basic(t *testing.T) {
 
 // TestAppendCommand_WithFlags tests APPEND with flags
 func TestAppendCommand_WithFlags(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n\r\nBody\r\n"
 	appendCmd := fmt.Sprintf("A002 APPEND Sent (\\Seen) {%d}", len(message))
@@ -68,8 +69,8 @@ func TestAppendCommand_WithFlags(t *testing.T) {
 
 // TestAppendCommand_NotAuthenticated tests APPEND without authentication
 func TestAppendCommand_NotAuthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	state := &models.ClientState{
 		Authenticated: false,
@@ -94,10 +95,10 @@ func TestAppendCommand_NotAuthenticated(t *testing.T) {
 
 // TestAppendCommand_InvalidFolder tests APPEND to non-existent folder
 func TestAppendCommand_InvalidFolder(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "Test message"
 	appendCmd := fmt.Sprintf("A004 APPEND NonExistent {%d}", len(message))
@@ -118,9 +119,9 @@ func TestAppendCommand_InvalidFolder(t *testing.T) {
 
 // TestAppendCommand_ToINBOX tests APPEND to INBOX folder
 func TestAppendCommand_ToINBOX(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: INBOX Test\r\n\r\nINBOX test message.\r\n"
 	appendCmd := fmt.Sprintf("A005 APPEND INBOX {%d}", len(message))
@@ -139,9 +140,9 @@ func TestAppendCommand_ToINBOX(t *testing.T) {
 
 // TestAppendCommand_ToDrafts tests APPEND to Drafts folder
 func TestAppendCommand_ToDrafts(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: sender@example.com\r\nSubject: Draft\r\n\r\nDraft message.\r\n"
 	appendCmd := fmt.Sprintf("A006 APPEND Drafts (\\Draft) {%d}", len(message))
@@ -160,10 +161,10 @@ func TestAppendCommand_ToDrafts(t *testing.T) {
 
 // TestAppendCommand_MissingSize tests APPEND without literal size
 func TestAppendCommand_MissingSize(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	appendCmd := "A007 APPEND Sent"
 	parts := strings.Fields(appendCmd)
@@ -179,13 +180,13 @@ func TestAppendCommand_MissingSize(t *testing.T) {
 
 // TestAppendCommand_RFC3501Example tests the exact example from RFC 3501
 func TestAppendCommand_RFC3501Example(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Create the saved-messages mailbox first (as per RFC example)
-	database := GetDatabaseFromServer(srv)
-	CreateMailbox(t, database, "testuser", "saved-messages")
+	database := server.GetDatabaseFromServer(srv)
+	server.CreateMailbox(t, database,"testuser", "saved-messages")
 
 	// RFC 3501 example message
 	message := "Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)\r\n" +
@@ -222,9 +223,9 @@ func TestAppendCommand_RFC3501Example(t *testing.T) {
 
 // TestAppendCommand_MultipleFlags tests APPEND with multiple flags
 func TestAppendCommand_MultipleFlags(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: test@example.com\r\nSubject: Test\r\n\r\nBody\r\n"
 	appendCmd := fmt.Sprintf("A008 APPEND INBOX (\\Seen \\Flagged) {%d}", len(message))
@@ -243,9 +244,9 @@ func TestAppendCommand_MultipleFlags(t *testing.T) {
 
 // TestAppendCommand_EmptyMessage tests APPEND with empty message
 func TestAppendCommand_EmptyMessage(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := ""
 	appendCmd := fmt.Sprintf("A009 APPEND INBOX {%d}", len(message))
@@ -265,9 +266,9 @@ func TestAppendCommand_EmptyMessage(t *testing.T) {
 
 // TestAppendCommand_LargeMessage tests APPEND with a large message
 func TestAppendCommand_LargeMessage(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Create a 1MB message
 	messageSize := 1024 * 1024
@@ -290,10 +291,10 @@ func TestAppendCommand_LargeMessage(t *testing.T) {
 
 // TestAppendCommand_InvalidSize tests APPEND with negative size
 func TestAppendCommand_InvalidSize(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	appendCmd := "A011 APPEND INBOX {-1}"
 	parts := strings.Fields(appendCmd)
@@ -309,10 +310,10 @@ func TestAppendCommand_InvalidSize(t *testing.T) {
 
 // TestAppendCommand_ExcessiveSize tests APPEND with size exceeding limit
 func TestAppendCommand_ExcessiveSize(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Try to append a message larger than 50MB limit
 	appendCmd := "A012 APPEND INBOX {52428801}" // 50MB + 1 byte
@@ -333,9 +334,9 @@ func TestAppendCommand_ExcessiveSize(t *testing.T) {
 
 // TestAppendCommand_QuotedMailboxName tests APPEND to a quoted mailbox name
 func TestAppendCommand_QuotedMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: test@example.com\r\nSubject: Test\r\n\r\nBody\r\n"
 	appendCmd := fmt.Sprintf("A013 APPEND \"Sent\" {%d}", len(message))
@@ -354,9 +355,9 @@ func TestAppendCommand_QuotedMailboxName(t *testing.T) {
 
 // TestAppendCommand_WithoutFlags tests APPEND without optional flags
 func TestAppendCommand_WithoutFlags(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: test@example.com\r\nSubject: No Flags\r\n\r\nMessage without flags\r\n"
 	appendCmd := fmt.Sprintf("A014 APPEND INBOX {%d}", len(message))
@@ -375,10 +376,10 @@ func TestAppendCommand_WithoutFlags(t *testing.T) {
 
 // TestAppendCommand_MissingMailboxName tests APPEND without mailbox name
 func TestAppendCommand_MissingMailboxName(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	appendCmd := "A015 APPEND"
 	parts := strings.Fields(appendCmd)
@@ -398,9 +399,9 @@ func TestAppendCommand_MissingMailboxName(t *testing.T) {
 
 // TestAppendCommand_8BitCharacters tests APPEND with 8-bit characters
 func TestAppendCommand_8BitCharacters(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Message with UTF-8 characters (8-bit)
 	message := "From: test@example.com\r\nSubject: Tëst Mëssägë\r\n\r\nBody with 8-bit: café, naïve, résumé\r\n"
@@ -424,9 +425,9 @@ func TestAppendCommand_AllDefaultMailboxes(t *testing.T) {
 
 	for _, mailbox := range defaultMailboxes {
 		t.Run(mailbox, func(t *testing.T) {
-			srv := SetupTestServerSimple(t)
-			conn := NewMockConn()
-			state := SetupAuthenticatedState(t, srv, "testuser")
+			srv := server.SetupTestServerSimple(t)
+			conn := server.NewMockConn()
+			state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 			message := fmt.Sprintf("From: test@example.com\r\nSubject: Test to %s\r\n\r\nBody\r\n", mailbox)
 			appendCmd := fmt.Sprintf("A017 APPEND %s {%d}", mailbox, len(message))
@@ -447,9 +448,9 @@ func TestAppendCommand_AllDefaultMailboxes(t *testing.T) {
 
 // TestAppendCommand_ReturnsAppendUID tests that APPEND returns APPENDUID
 func TestAppendCommand_ReturnsAppendUID(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	message := "From: test@example.com\r\nSubject: UID Test\r\n\r\nBody\r\n"
 	appendCmd := fmt.Sprintf("A018 APPEND INBOX {%d}", len(message))
@@ -472,9 +473,9 @@ func TestAppendCommand_ReturnsAppendUID(t *testing.T) {
 
 // TestAppendCommand_MessageParsing tests that message headers are parsed correctly
 func TestAppendCommand_MessageParsing(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Message with all important headers
 	message := "Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)\r\n" +
@@ -500,9 +501,9 @@ func TestAppendCommand_MessageParsing(t *testing.T) {
 
 // TestAppendCommand_LiteralPlus tests APPEND with LITERAL+ (non-synchronizing literal)
 func TestAppendCommand_LiteralPlus(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Test LITERAL+ syntax: {size+} means client sends data immediately
 	message := "From: sender@example.com\r\nSubject: Test LITERAL+\r\n\r\nBody\r\n"

--- a/internal/server/message/handler_message_check_test.go
+++ b/internal/server/message/handler_message_check_test.go
@@ -1,18 +1,19 @@
 //go:build test
 
-package message
+package message_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
+	"raven/internal/server"
 )
 
 // TestCheckCommand_Unauthenticated tests CHECK before authentication
 func TestCheckCommand_Unauthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -36,8 +37,8 @@ func TestCheckCommand_Unauthenticated(t *testing.T) {
 
 // TestCheckCommand_AuthenticatedNoMailbox tests CHECK when authenticated but no mailbox selected
 func TestCheckCommand_AuthenticatedNoMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated:     true,
 		Username:          "testuser",
@@ -63,15 +64,15 @@ func TestCheckCommand_AuthenticatedNoMailbox(t *testing.T) {
 
 // TestCheckCommand_WithSelectedMailbox tests CHECK with selected mailbox
 func TestCheckCommand_WithSelectedMailbox(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// Setup authenticated state with selected mailbox
-	state := SetupAuthenticatedState(t, srv, "testuser")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
 
 	// Set selected mailbox ID (INBOX was created by SetupAuthenticatedState)
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -100,13 +101,13 @@ func TestCheckCommand_WithSelectedMailbox(t *testing.T) {
 // Per RFC 3501: "There is no guarantee that an EXISTS untagged response will
 // happen as a result of CHECK"
 func TestCheckCommand_NoExistsResponse(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// Setup authenticated state with selected mailbox
-	state := SetupAuthenticatedState(t, srv, "testuser")
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -135,13 +136,13 @@ func TestCheckCommand_NoExistsResponse(t *testing.T) {
 
 // TestCheckCommand_AlwaysSucceeds tests that CHECK always returns OK when mailbox is selected
 func TestCheckCommand_AlwaysSucceeds(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// Setup authenticated state with selected mailbox
-	state := SetupAuthenticatedState(t, srv, "testuser")
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -166,12 +167,12 @@ func TestCheckCommand_AlwaysSucceeds(t *testing.T) {
 
 // TestCheckCommand_ResponseFormat tests the format of CHECK responses
 func TestCheckCommand_ResponseFormat(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -198,12 +199,12 @@ func TestCheckCommand_ResponseFormat(t *testing.T) {
 
 // TestCheckCommand_MultipleInvocations tests calling CHECK multiple times
 func TestCheckCommand_MultipleInvocations(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
-	state := SetupAuthenticatedState(t, srv, "testuser")
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -231,13 +232,13 @@ func TestCheckCommand_MultipleInvocations(t *testing.T) {
 
 // TestCheckCommand_StateTracking tests that CHECK updates state correctly
 func TestCheckCommand_StateTracking(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 
 	// Setup authenticated state with selected mailbox
-	state := SetupAuthenticatedState(t, srv, "testuser")
-	database := GetDatabaseFromServer(srv)
-	mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+	state := server.SetupAuthenticatedState(t, srv,"testuser")
+	database := server.GetDatabaseFromServer(srv)
+	mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 	if err != nil {
 		t.Fatalf("Failed to get INBOX mailbox: %v", err)
 	}
@@ -280,12 +281,12 @@ func TestCheckCommand_TagHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Tag_"+tc.tag, func(t *testing.T) {
-			srv := SetupTestServerSimple(t)
-			conn := NewMockConn()
+			srv := server.SetupTestServerSimple(t)
+			conn := server.NewMockConn()
 
-			state := SetupAuthenticatedState(t, srv, "testuser")
-			database := GetDatabaseFromServer(srv)
-			mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+			state := server.SetupAuthenticatedState(t, srv,"testuser")
+			database := server.GetDatabaseFromServer(srv)
+			mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 			if err != nil {
 				t.Fatalf("Failed to get INBOX mailbox: %v", err)
 			}
@@ -306,7 +307,7 @@ func TestCheckCommand_TagHandling(t *testing.T) {
 
 // TestCheckCommand_ConcurrentAccess tests concurrent CHECK requests
 func TestCheckCommand_ConcurrentAccess(t *testing.T) {
-	srv := SetupTestServerSimple(t)
+	srv := server.SetupTestServerSimple(t)
 
 	const numRequests = 20
 	done := make(chan bool, numRequests)
@@ -314,10 +315,10 @@ func TestCheckCommand_ConcurrentAccess(t *testing.T) {
 	// Launch concurrent CHECK requests
 	for i := 0; i < numRequests; i++ {
 		go func(index int) {
-			conn := NewMockConn()
-			state := SetupAuthenticatedState(t, srv, "user")
-			database := GetDatabaseFromServer(srv)
-			mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+			conn := server.NewMockConn()
+			state := server.SetupAuthenticatedState(t, srv,"user")
+			database := server.GetDatabaseFromServer(srv)
+			mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 			if err != nil {
 				t.Fatalf("Failed to get INBOX mailbox: %v", err)
 			}
@@ -343,8 +344,8 @@ func TestCheckCommand_ConcurrentAccess(t *testing.T) {
 // TestCheckCommand_RFC3501Compliance tests RFC 3501 compliance
 func TestCheckCommand_RFC3501Compliance(t *testing.T) {
 	t.Run("Requires Selected state", func(t *testing.T) {
-		srv := SetupTestServerSimple(t)
-		conn := NewMockConn()
+		srv := server.SetupTestServerSimple(t)
+		conn := server.NewMockConn()
 
 		// Authenticated but no mailbox selected
 		state := &models.ClientState{
@@ -362,12 +363,12 @@ func TestCheckCommand_RFC3501Compliance(t *testing.T) {
 	})
 
 	t.Run("Always succeeds in Selected state", func(t *testing.T) {
-		srv := SetupTestServerSimple(t)
-		conn := NewMockConn()
+		srv := server.SetupTestServerSimple(t)
+		conn := server.NewMockConn()
 
-		state := SetupAuthenticatedState(t, srv, "testuser")
-		database := GetDatabaseFromServer(srv)
-		mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+		state := server.SetupAuthenticatedState(t, srv,"testuser")
+		database := server.GetDatabaseFromServer(srv)
+		mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 		if err != nil {
 			t.Fatalf("Failed to get INBOX mailbox: %v", err)
 		}
@@ -383,12 +384,12 @@ func TestCheckCommand_RFC3501Compliance(t *testing.T) {
 	})
 
 	t.Run("No guaranteed EXISTS response", func(t *testing.T) {
-		srv := SetupTestServerSimple(t)
-		conn := NewMockConn()
+		srv := server.SetupTestServerSimple(t)
+		conn := server.NewMockConn()
 
-		state := SetupAuthenticatedState(t, srv, "testuser")
-		database := GetDatabaseFromServer(srv)
-		mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+		state := server.SetupAuthenticatedState(t, srv,"testuser")
+		database := server.GetDatabaseFromServer(srv)
+		mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 		if err != nil {
 			t.Fatalf("Failed to get INBOX mailbox: %v", err)
 		}
@@ -416,12 +417,12 @@ func TestCheckCommand_RFC3501Compliance(t *testing.T) {
 	t.Run("Housekeeping operation", func(t *testing.T) {
 		// This test verifies that CHECK performs housekeeping
 		// by synchronizing in-memory state with database state
-		srv := SetupTestServerSimple(t)
-		conn := NewMockConn()
+		srv := server.SetupTestServerSimple(t)
+		conn := server.NewMockConn()
 
-		state := SetupAuthenticatedState(t, srv, "testuser")
-		database := GetDatabaseFromServer(srv)
-		mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+		state := server.SetupAuthenticatedState(t, srv,"testuser")
+		database := server.GetDatabaseFromServer(srv)
+		mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 		if err != nil {
 			t.Fatalf("Failed to get INBOX mailbox: %v", err)
 		}
@@ -450,10 +451,10 @@ func TestCheckCommand_RFC3501Compliance(t *testing.T) {
 // TestCheckCommand_VsNoop tests the difference between CHECK and NOOP
 func TestCheckCommand_VsNoop(t *testing.T) {
 	t.Run("CHECK requires Selected state, NOOP does not", func(t *testing.T) {
-		srv := SetupTestServerSimple(t)
+		srv := server.SetupTestServerSimple(t)
 
 		// Test NOOP without selected mailbox
-		connNoop := NewMockConn()
+		connNoop := server.NewMockConn()
 		stateNoop := &models.ClientState{
 			Authenticated: true,
 			Username:      "testuser",
@@ -462,7 +463,7 @@ func TestCheckCommand_VsNoop(t *testing.T) {
 		noopResponse := connNoop.GetWrittenData()
 
 		// Test CHECK without selected mailbox
-		connCheck := NewMockConn()
+		connCheck := server.NewMockConn()
 		stateCheck := &models.ClientState{
 			Authenticated: true,
 			Username:      "testuser",
@@ -484,11 +485,11 @@ func TestCheckCommand_VsNoop(t *testing.T) {
 	t.Run("NOOP used for polling, CHECK for housekeeping", func(t *testing.T) {
 		// This is documented in RFC 3501 but behavioral difference is subtle
 		// NOOP can send EXISTS, CHECK does not guarantee it
-		srv := SetupTestServerSimple(t)
+		srv := server.SetupTestServerSimple(t)
 
-		state := SetupAuthenticatedState(t, srv, "testuser")
-		database := GetDatabaseFromServer(srv)
-		mailboxID, err := GetMailboxID(t, database, state.UserID, "INBOX")
+		state := server.SetupAuthenticatedState(t, srv,"testuser")
+		database := server.GetDatabaseFromServer(srv)
+		mailboxID, err := server.GetMailboxID(t, database,state.UserID, "INBOX")
 		if err != nil {
 			t.Fatalf("Failed to get INBOX mailbox: %v", err)
 		}
@@ -496,7 +497,7 @@ func TestCheckCommand_VsNoop(t *testing.T) {
 		state.SelectedFolder = "INBOX"
 
 		// CHECK should not send untagged responses
-		connCheck := NewMockConn()
+		connCheck := server.NewMockConn()
 		srv.HandleCheck(connCheck, "C001", state)
 		checkResponse := connCheck.GetWrittenData()
 

--- a/internal/server/message/handler_message_fetch_test.go
+++ b/internal/server/message/handler_message_fetch_test.go
@@ -1,18 +1,19 @@
 //go:build test
 
-package message
+package message_test
 
 import (
 	"strings"
 	"testing"
 
 	"raven/internal/models"
+	"raven/internal/server"
 )
 
 // TestFetchCommand_Unauthenticated tests FETCH without authentication
 func TestFetchCommand_Unauthenticated(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -27,11 +28,11 @@ func TestFetchCommand_Unauthenticated(t *testing.T) {
 
 // TestFetchCommand_NoMailboxSelected tests FETCH without mailbox selection
 func TestFetchCommand_NoMailboxSelected(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
+	userID := server.CreateTestUser(t, database, "testuser")
 	state := &models.ClientState{
 		Authenticated:     true,
 		UserID:            userID,
@@ -49,14 +50,14 @@ func TestFetchCommand_NoMailboxSelected(t *testing.T) {
 
 // TestFetchCommand_FLAGS tests FETCH FLAGS
 func TestFetchCommand_FLAGS(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	msg1ID := InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	msg1ID := server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -64,7 +65,7 @@ func TestFetchCommand_FLAGS(t *testing.T) {
 		Username:          "testuser",
 		SelectedMailboxID: mailboxID,
 	}
-	userDB := GetUserDBByID(t, database, state.UserID)
+	userDB := server.GetUserDBByID(t, database, state.UserID)
 
 	// Set some flags
 	userDB.Exec(`UPDATE message_mailbox SET flags = '\Seen \Flagged' WHERE message_id = ? AND mailbox_id = ?`, msg1ID, mailboxID)
@@ -85,14 +86,14 @@ func TestFetchCommand_FLAGS(t *testing.T) {
 
 // TestFetchCommand_UID tests FETCH UID
 func TestFetchCommand_UID(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -114,14 +115,14 @@ func TestFetchCommand_UID(t *testing.T) {
 
 // TestFetchCommand_INTERNALDATE tests FETCH INTERNALDATE
 func TestFetchCommand_INTERNALDATE(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -140,14 +141,14 @@ func TestFetchCommand_INTERNALDATE(t *testing.T) {
 
 // TestFetchCommand_RFC822SIZE tests FETCH RFC822.SIZE
 func TestFetchCommand_RFC822SIZE(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -166,14 +167,14 @@ func TestFetchCommand_RFC822SIZE(t *testing.T) {
 
 // TestFetchCommand_ENVELOPE tests FETCH ENVELOPE
 func TestFetchCommand_ENVELOPE(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -196,14 +197,14 @@ func TestFetchCommand_ENVELOPE(t *testing.T) {
 
 // TestFetchCommand_BODYSTRUCTURE tests FETCH BODYSTRUCTURE
 func TestFetchCommand_BODYSTRUCTURE(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -222,14 +223,14 @@ func TestFetchCommand_BODYSTRUCTURE(t *testing.T) {
 
 // TestFetchCommand_BODY tests FETCH BODY (non-extensible BODYSTRUCTURE)
 func TestFetchCommand_BODY(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -249,14 +250,14 @@ func TestFetchCommand_BODY(t *testing.T) {
 
 // TestFetchCommand_MacroALL tests FETCH ALL macro
 func TestFetchCommand_MacroALL(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -285,14 +286,14 @@ func TestFetchCommand_MacroALL(t *testing.T) {
 
 // TestFetchCommand_MacroFAST tests FETCH FAST macro
 func TestFetchCommand_MacroFAST(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -318,14 +319,14 @@ func TestFetchCommand_MacroFAST(t *testing.T) {
 
 // TestFetchCommand_MacroFULL tests FETCH FULL macro
 func TestFetchCommand_MacroFULL(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -357,17 +358,17 @@ func TestFetchCommand_MacroFULL(t *testing.T) {
 
 // TestFetchCommand_SequenceRange tests FETCH with sequence range
 func TestFetchCommand_SequenceRange(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Message 1", "sender@test.com", "testuser@localhost", "INBOX")
-	InsertTestMail(t, database, "testuser", "Message 2", "sender@test.com", "testuser@localhost", "INBOX")
-	InsertTestMail(t, database, "testuser", "Message 3", "sender@test.com", "testuser@localhost", "INBOX")
-	InsertTestMail(t, database, "testuser", "Message 4", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Message 1", "sender@test.com", "testuser@localhost", "INBOX")
+	server.InsertTestMail(t, database, "testuser", "Message 2", "sender@test.com", "testuser@localhost", "INBOX")
+	server.InsertTestMail(t, database, "testuser", "Message 3", "sender@test.com", "testuser@localhost", "INBOX")
+	server.InsertTestMail(t, database, "testuser", "Message 4", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -394,14 +395,14 @@ func TestFetchCommand_SequenceRange(t *testing.T) {
 
 // TestFetchCommand_MultipleItems tests FETCH with multiple items
 func TestFetchCommand_MultipleItems(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -429,14 +430,14 @@ func TestFetchCommand_MultipleItems(t *testing.T) {
 
 // TestFetchCommand_BODY_HEADER tests FETCH BODY[HEADER]
 func TestFetchCommand_BODY_HEADER(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -459,14 +460,14 @@ func TestFetchCommand_BODY_HEADER(t *testing.T) {
 
 // TestFetchCommand_BODY_TEXT tests FETCH BODY[TEXT]
 func TestFetchCommand_BODY_TEXT(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -485,14 +486,14 @@ func TestFetchCommand_BODY_TEXT(t *testing.T) {
 
 // TestFetchCommand_BODY_PEEK tests FETCH BODY.PEEK[]
 func TestFetchCommand_BODY_PEEK(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -513,14 +514,14 @@ func TestFetchCommand_BODY_PEEK(t *testing.T) {
 
 // TestFetchCommand_RFC822 tests FETCH RFC822
 func TestFetchCommand_RFC822(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -540,14 +541,14 @@ func TestFetchCommand_RFC822(t *testing.T) {
 
 // TestFetchCommand_RFC822_HEADER tests FETCH RFC822.HEADER
 func TestFetchCommand_RFC822_HEADER(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -566,14 +567,14 @@ func TestFetchCommand_RFC822_HEADER(t *testing.T) {
 
 // TestFetchCommand_RFC822_TEXT tests FETCH RFC822.TEXT
 func TestFetchCommand_RFC822_TEXT(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test Subject", "sender@test.com", "testuser@localhost", "INBOX")
 
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -592,12 +593,12 @@ func TestFetchCommand_RFC822_TEXT(t *testing.T) {
 
 // TestFetchCommand_BadSyntax tests FETCH with invalid syntax
 func TestFetchCommand_BadSyntax(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	conn := NewMockConn()
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	conn := server.NewMockConn()
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -616,12 +617,12 @@ func TestFetchCommand_BadSyntax(t *testing.T) {
 
 // TestFetchCommand_TagHandling tests various tag formats
 func TestFetchCommand_TagHandling(t *testing.T) {
-	srv := SetupTestServerSimple(t)
-	database := GetDatabaseFromServer(srv)
+	srv := server.SetupTestServerSimple(t)
+	database := server.GetDatabaseFromServer(srv)
 
-	userID := CreateTestUser(t, database, "testuser")
-	InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
-	mailboxID, _ := GetMailboxID(t, database, userID, "INBOX")
+	userID := server.CreateTestUser(t, database, "testuser")
+	server.InsertTestMail(t, database, "testuser", "Test", "sender@test.com", "testuser@localhost", "INBOX")
+	mailboxID, _ := server.GetMailboxID(t, database, userID, "INBOX")
 
 	state := &models.ClientState{
 		Authenticated:     true,
@@ -634,7 +635,7 @@ func TestFetchCommand_TagHandling(t *testing.T) {
 
 	for _, tag := range testCases {
 		t.Run("Tag "+tag, func(t *testing.T) {
-			conn := NewMockConn()
+			conn := server.NewMockConn()
 			srv.HandleFetch(conn, tag, []string{tag, "FETCH", "1", "FLAGS"}, state)
 
 			response := conn.GetWrittenData()


### PR DESCRIPTION
## 📌 Description

This PR is to improve the test coverage of internal/server/message folder.
Test Coverage: 71.8%

- Closes #141 

---

## 🔍 Changes Made

- Improve the test coverage of the message folder

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
