### PR TITLE
refactor: separate YAML parsing logic into ParseConfig function and e…

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1,9 +1,9 @@
 package conf
 
 import (
+	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
-	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
@@ -11,9 +11,17 @@ type Config struct {
 	AuthServerURL string `yaml:"auth_server_url"`
 }
 
-func LoadConfig() (*Config, error) {
+// ParseConfig parses YAML configuration data and returns a Config struct.
+// This function is designed for unit testing and doesn't perform any I/O.
+func ParseConfig(data []byte) (*Config, error) {
 	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
 
+func LoadConfig() (*Config, error) {
 	// Try multiple possible paths
 	configPaths := []string{
 		"/etc/raven/raven.yaml",
@@ -34,9 +42,5 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, err
-	}
-
-	return &cfg, nil
+	return ParseConfig(data)
 }

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -1,13 +1,11 @@
 package conf
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 )
 
-func TestConfig_YAMLTags(t *testing.T) {
-	// Test that Config struct has correct YAML tags
+// Unit test: Tests Config struct field assignment
+func TestConfig_FieldAssignment(t *testing.T) {
 	cfg := Config{
 		Domain:        "example.com",
 		AuthServerURL: "https://auth.example.com",
@@ -21,39 +19,31 @@ func TestConfig_YAMLTags(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_Success(t *testing.T) {
-	// Create a temporary config file
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
+// Unit test: Tests Config struct zero values
+func TestConfig_ZeroValues(t *testing.T) {
+	cfg := Config{}
 
-	configContent := `domain: test.example.com
+	if cfg.Domain != "" {
+		t.Errorf("Expected empty domain, got '%s'", cfg.Domain)
+	}
+	if cfg.AuthServerURL != "" {
+		t.Errorf("Expected empty auth_server_url, got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with valid complete YAML
+func TestParseConfig_ValidCompleteYAML(t *testing.T) {
+	yamlData := []byte(`domain: test.example.com
 auth_server_url: https://auth.test.example.com
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	// Change to temp directory so config can be found
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
 
 	if cfg == nil {
 		t.Fatal("Expected config to be non-nil")
-		return
 	}
 
 	if cfg.Domain != "test.example.com" {
@@ -65,89 +55,32 @@ auth_server_url: https://auth.test.example.com
 	}
 }
 
-func TestLoadConfig_MissingFile(t *testing.T) {
-	// Change to a temp directory with no config file
-	tmpDir := t.TempDir()
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	_, err = LoadConfig()
-	if err == nil {
-		t.Error("Expected error for missing config file, got nil")
-	}
-}
-
-func TestLoadConfig_InvalidYAML(t *testing.T) {
-	// Create a temporary config file with invalid YAML
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
-
-	invalidYAML := `domain: test.example.com
+// Unit test: Tests ParseConfig with invalid YAML syntax
+func TestParseConfig_InvalidYAML(t *testing.T) {
+	invalidYAML := []byte(`domain: test.example.com
 auth_server_url: [invalid yaml structure
   missing closing bracket
-`
-	err := os.WriteFile(configPath, []byte(invalidYAML), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	_, err = LoadConfig()
+	_, err := ParseConfig(invalidYAML)
 	if err == nil {
 		t.Error("Expected error for invalid YAML, got nil")
 	}
 }
 
-func TestLoadConfig_EmptyFile(t *testing.T) {
-	// Create an empty config file
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
+// Unit test: Tests ParseConfig with empty data
+func TestParseConfig_EmptyData(t *testing.T) {
+	emptyData := []byte("")
 
-	err := os.WriteFile(configPath, []byte(""), 0600)
+	cfg, err := ParseConfig(emptyData)
 	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
-
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
-	if err != nil {
-		t.Fatalf("Expected no error for empty file, got: %v", err)
+		t.Fatalf("Expected no error for empty data, got: %v", err)
 	}
 
 	if cfg == nil {
 		t.Fatal("Expected config to be non-nil")
-		return
 	}
 
-	// Empty file should result in empty config fields
 	if cfg.Domain != "" {
 		t.Errorf("Expected empty domain, got '%s'", cfg.Domain)
 	}
@@ -156,30 +89,12 @@ func TestLoadConfig_EmptyFile(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_PartialConfig(t *testing.T) {
-	// Create a config file with only one field
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
+// Unit test: Tests ParseConfig with partial configuration
+func TestParseConfig_PartialConfig(t *testing.T) {
+	yamlData := []byte(`domain: partial.example.com
+`)
 
-	configContent := `domain: partial.example.com
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
-
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -193,33 +108,34 @@ func TestLoadConfig_PartialConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_WithComments(t *testing.T) {
-	// Create a config file with YAML comments
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
+// Unit test: Tests ParseConfig with only auth_server_url
+func TestParseConfig_OnlyAuthServerURL(t *testing.T) {
+	yamlData := []byte(`auth_server_url: https://auth.only.example.com
+`)
 
-	configContent := `# This is a comment
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "" {
+		t.Errorf("Expected empty domain, got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "https://auth.only.example.com" {
+		t.Errorf("Expected auth_server_url 'https://auth.only.example.com', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with YAML comments
+func TestParseConfig_WithComments(t *testing.T) {
+	yamlData := []byte(`# This is a comment
 domain: commented.example.com
 # Another comment
 auth_server_url: https://auth.commented.example.com
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -227,72 +143,19 @@ auth_server_url: https://auth.commented.example.com
 	if cfg.Domain != "commented.example.com" {
 		t.Errorf("Expected domain 'commented.example.com', got '%s'", cfg.Domain)
 	}
-}
 
-func TestLoadConfig_ConfigSubdirectory(t *testing.T) {
-	// Test loading from config/ subdirectory
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "config")
-	err := os.Mkdir(configDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create config directory: %v", err)
-	}
-
-	configPath := filepath.Join(configDir, "raven.yaml")
-	configContent := `domain: subdir.example.com
-auth_server_url: https://auth.subdir.example.com
-`
-	err = os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
-
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if cfg.Domain != "subdir.example.com" {
-		t.Errorf("Expected domain 'subdir.example.com', got '%s'", cfg.Domain)
+	if cfg.AuthServerURL != "https://auth.commented.example.com" {
+		t.Errorf("Expected auth_server_url 'https://auth.commented.example.com', got '%s'", cfg.AuthServerURL)
 	}
 }
 
-func TestLoadConfig_SpecialCharacters(t *testing.T) {
-	// Test config with special characters in values
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
-
-	configContent := `domain: "test-domain.example.com"
+// Unit test: Tests ParseConfig with special characters in values
+func TestParseConfig_SpecialCharacters(t *testing.T) {
+	yamlData := []byte(`domain: "test-domain.example.com"
 auth_server_url: "https://auth.example.com:8443/api/v1"
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -306,33 +169,15 @@ auth_server_url: "https://auth.example.com:8443/api/v1"
 	}
 }
 
-func TestLoadConfig_WhitespaceHandling(t *testing.T) {
-	// Test config with extra whitespace
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
-
-	configContent := `
+// Unit test: Tests ParseConfig with extra whitespace
+func TestParseConfig_WhitespaceHandling(t *testing.T) {
+	yamlData := []byte(`
 domain:   whitespace.example.com
 auth_server_url:   https://auth.whitespace.example.com
 
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -341,34 +186,20 @@ auth_server_url:   https://auth.whitespace.example.com
 	if cfg.Domain != "whitespace.example.com" {
 		t.Errorf("Expected domain 'whitespace.example.com', got '%s'", cfg.Domain)
 	}
+
+	if cfg.AuthServerURL != "https://auth.whitespace.example.com" {
+		t.Errorf("Expected auth_server_url 'https://auth.whitespace.example.com', got '%s'", cfg.AuthServerURL)
+	}
 }
 
-func TestLoadConfig_CaseSensitiveKeys(t *testing.T) {
-	// Test that YAML keys are case-sensitive
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "raven.yaml")
-
+// Unit test: Tests ParseConfig with case-sensitive YAML keys
+func TestParseConfig_CaseSensitiveKeys(t *testing.T) {
 	// Use uppercase keys (should not match lowercase struct tags)
-	configContent := `Domain: uppercase.example.com
+	yamlData := []byte(`Domain: uppercase.example.com
 Auth_Server_URL: https://auth.uppercase.example.com
-`
-	err := os.WriteFile(configPath, []byte(configContent), 0600)
-	if err != nil {
-		t.Fatalf("Failed to create test config file: %v", err)
-	}
+`)
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	defer func() { _ = os.Chdir(originalDir) }()
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	cfg, err := LoadConfig()
+	cfg, err := ParseConfig(yamlData)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -376,5 +207,213 @@ Auth_Server_URL: https://auth.uppercase.example.com
 	// Keys with wrong case should not populate fields
 	if cfg.Domain != "" {
 		t.Errorf("Expected empty domain (case mismatch), got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "" {
+		t.Errorf("Expected empty auth_server_url (case mismatch), got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with correct lowercase keys
+func TestParseConfig_CorrectCaseKeys(t *testing.T) {
+	yamlData := []byte(`domain: correct.example.com
+auth_server_url: https://auth.correct.example.com
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "correct.example.com" {
+		t.Errorf("Expected domain 'correct.example.com', got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "https://auth.correct.example.com" {
+		t.Errorf("Expected auth_server_url 'https://auth.correct.example.com', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with malformed YAML (unclosed quotes)
+func TestParseConfig_MalformedYAML_UnclosedQuotes(t *testing.T) {
+	yamlData := []byte(`domain: "unclosed.example.com
+auth_server_url: https://auth.example.com
+`)
+
+	_, err := ParseConfig(yamlData)
+	if err == nil {
+		t.Error("Expected error for malformed YAML with unclosed quotes, got nil")
+	}
+}
+
+// Unit test: Tests ParseConfig with malformed YAML (invalid indentation)
+func TestParseConfig_MalformedYAML_InvalidIndentation(t *testing.T) {
+	yamlData := []byte(`domain: test.example.com
+  auth_server_url: https://auth.example.com
+`)
+
+	_, err := ParseConfig(yamlData)
+	if err == nil {
+		t.Error("Expected error for malformed YAML with invalid indentation, got nil")
+	}
+}
+
+// Unit test: Tests ParseConfig with nil data
+func TestParseConfig_NilData(t *testing.T) {
+	var nilData []byte = nil
+
+	cfg, err := ParseConfig(nilData)
+	if err != nil {
+		t.Fatalf("Expected no error for nil data, got: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("Expected config to be non-nil")
+	}
+
+	if cfg.Domain != "" {
+		t.Errorf("Expected empty domain, got '%s'", cfg.Domain)
+	}
+	if cfg.AuthServerURL != "" {
+		t.Errorf("Expected empty auth_server_url, got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with URL containing query parameters
+func TestParseConfig_URLWithQueryParams(t *testing.T) {
+	yamlData := []byte(`domain: query.example.com
+auth_server_url: https://auth.example.com/login?redirect=true&timeout=30
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	expectedURL := "https://auth.example.com/login?redirect=true&timeout=30"
+	if cfg.AuthServerURL != expectedURL {
+		t.Errorf("Expected auth_server_url '%s', got '%s'", expectedURL, cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with multiline YAML string (using folded style)
+func TestParseConfig_MultilineString(t *testing.T) {
+	yamlData := []byte(`domain: >
+  multi.example.com
+auth_server_url: https://auth.example.com
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Folded style should convert to single line with trailing newline removed
+	if cfg.Domain != "multi.example.com\n" {
+		t.Errorf("Expected domain 'multi.example.com\\n', got '%s'", cfg.Domain)
+	}
+}
+
+// Unit test: Tests ParseConfig with extra unknown fields (should be ignored)
+func TestParseConfig_ExtraFields(t *testing.T) {
+	yamlData := []byte(`domain: extra.example.com
+auth_server_url: https://auth.example.com
+unknown_field: this should be ignored
+another_unknown: also ignored
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "extra.example.com" {
+		t.Errorf("Expected domain 'extra.example.com', got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "https://auth.example.com" {
+		t.Errorf("Expected auth_server_url 'https://auth.example.com', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with numeric values treated as strings
+func TestParseConfig_NumericAsString(t *testing.T) {
+	yamlData := []byte(`domain: "12345"
+auth_server_url: "67890"
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "12345" {
+		t.Errorf("Expected domain '12345', got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "67890" {
+		t.Errorf("Expected auth_server_url '67890', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with boolean-like values treated as strings
+func TestParseConfig_BooleanAsString(t *testing.T) {
+	yamlData := []byte(`domain: "true"
+auth_server_url: "false"
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "true" {
+		t.Errorf("Expected domain 'true', got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "false" {
+		t.Errorf("Expected auth_server_url 'false', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with unicode characters
+func TestParseConfig_UnicodeCharacters(t *testing.T) {
+	yamlData := []byte(`domain: "域名.example.com"
+auth_server_url: "https://认证.example.com/路径"
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if cfg.Domain != "域名.example.com" {
+		t.Errorf("Expected domain '域名.example.com', got '%s'", cfg.Domain)
+	}
+
+	if cfg.AuthServerURL != "https://认证.example.com/路径" {
+		t.Errorf("Expected auth_server_url 'https://认证.example.com/路径', got '%s'", cfg.AuthServerURL)
+	}
+}
+
+// Unit test: Tests ParseConfig with escaped characters
+func TestParseConfig_EscapedCharacters(t *testing.T) {
+	yamlData := []byte(`domain: "test\nexample.com"
+auth_server_url: "https://auth.example.com/path\twith\ttabs"
+`)
+
+	cfg, err := ParseConfig(yamlData)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	expectedDomain := "test\nexample.com"
+	if cfg.Domain != expectedDomain {
+		t.Errorf("Expected domain '%s', got '%s'", expectedDomain, cfg.Domain)
+	}
+
+	expectedURL := "https://auth.example.com/path\twith\ttabs"
+	if cfg.AuthServerURL != expectedURL {
+		t.Errorf("Expected auth_server_url '%s', got '%s'", expectedURL, cfg.AuthServerURL)
 	}
 }


### PR DESCRIPTION
## 📌 Description

This PR is to keep only the unit test cases in the internal/conf folder

- Closes #167 

---

## 🔍 Changes Made

- Make every test case as unit test case.

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
