### PR TITLE
feat: move blob table to shared.db for global deduplication

### DIFF
--- a/internal/db/db_manager_test.go
+++ b/internal/db/db_manager_test.go
@@ -323,7 +323,7 @@ func TestSharedDBTables(t *testing.T) {
 
 	sharedDB := manager.GetSharedDB()
 
-	expectedTables := []string{"domains", "users", "role_mailboxes", "user_role_assignments"}
+	expectedTables := []string{"domains", "users", "role_mailboxes", "user_role_assignments", "blobs"}
 	for _, tableName := range expectedTables {
 		var count int
 		err = sharedDB.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", tableName).Scan(&count)
@@ -356,7 +356,7 @@ func TestUserDBTables(t *testing.T) {
 	}
 
 	expectedTables := []string{
-		"blobs", "mailboxes", "aliases", "messages",
+		"mailboxes", "aliases", "messages",
 		"subscriptions", "addresses", "message_parts",
 		"deliveries", "message_mailbox", "message_headers",
 		"outbound_queue",
@@ -397,6 +397,7 @@ func TestSharedDBIndexes(t *testing.T) {
 		"idx_role_assignments_user",
 		"idx_role_assignments_role",
 		"idx_role_assignments_active",
+		"idx_blobs_hash",
 	}
 
 	for _, indexName := range expectedIndexes {
@@ -443,7 +444,6 @@ func TestUserDBIndexes(t *testing.T) {
 		"idx_message_mailbox_message",
 		"idx_message_mailbox_uid",
 		"idx_message_headers_message",
-		"idx_blobs_hash",
 		"idx_deliveries_message",
 		"idx_deliveries_status",
 		"idx_outbound_status",

--- a/internal/delivery/parser/parser_test.go
+++ b/internal/delivery/parser/parser_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"raven/internal/db"
 	"raven/internal/delivery/parser"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestParseMessage(t *testing.T) {
@@ -667,7 +668,7 @@ This is the message body.`
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
@@ -742,7 +743,7 @@ Content-Type: text/html; charset=utf-8
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
@@ -770,7 +771,7 @@ func TestStoreMessage_LargeContent(t *testing.T) {
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
@@ -802,7 +803,7 @@ Message body for user.`
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessagePerUser(database, parsed)
+	messageID, err := parser.StoreMessagePerUserWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message per user: %v", err)
 	}
@@ -839,12 +840,12 @@ Simple message body.`
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
 
-	reconstructed, err := parser.ReconstructMessage(database, messageID)
+	reconstructed, err := parser.ReconstructMessageWithSharedDB(database, database, messageID)
 	if err != nil {
 		t.Fatalf("Failed to reconstruct message: %v", err)
 	}
@@ -887,12 +888,12 @@ Content-Type: text/html; charset=utf-8
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
 
-	reconstructed, err := parser.ReconstructMessage(database, messageID)
+	reconstructed, err := parser.ReconstructMessageWithSharedDB(database, database, messageID)
 	if err != nil {
 		t.Fatalf("Failed to reconstruct message: %v", err)
 	}
@@ -936,12 +937,12 @@ Binary content
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
 
-	reconstructed, err := parser.ReconstructMessage(database, messageID)
+	reconstructed, err := parser.ReconstructMessageWithSharedDB(database, database, messageID)
 	if err != nil {
 		t.Fatalf("Failed to reconstruct message: %v", err)
 	}
@@ -963,7 +964,7 @@ func TestReconstructMessage_NoPartsError(t *testing.T) {
 	database := setupTestDB(t)
 	defer func() { _ = database.Close() }()
 
-	_, err := parser.ReconstructMessage(database, 99999)
+	_, err := parser.ReconstructMessageWithSharedDB(database, database, 99999)
 	if err == nil {
 		t.Error("Expected error when reconstructing non-existent message")
 	}
@@ -996,7 +997,7 @@ Content-Disposition: attachment; filename="large.bin"
 		t.Fatalf("Failed to parse message: %v", err)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
@@ -1049,12 +1050,12 @@ Content-Type: text/html; charset=utf-8
 		t.Errorf("Expected InReplyTo '<previous@example.com>', got '%s'", parsed.InReplyTo)
 	}
 
-	messageID, err := parser.StoreMessage(database, parsed)
+	messageID, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err != nil {
 		t.Fatalf("Failed to store message: %v", err)
 	}
 
-	reconstructed, err := parser.ReconstructMessage(database, messageID)
+	reconstructed, err := parser.ReconstructMessageWithSharedDB(database, database, messageID)
 	if err != nil {
 		t.Fatalf("Failed to reconstruct message: %v", err)
 	}
@@ -1088,7 +1089,7 @@ func TestStoreMessage_ErrorHandling(t *testing.T) {
 		From:    []mail.Address{{Address: "test@example.com"}},
 	}
 
-	_, err := parser.StoreMessage(database, parsed)
+	_, err := parser.StoreMessageWithSharedDB(database, database, parsed)
 	if err == nil {
 		t.Error("Expected error when storing to closed database")
 	}

--- a/internal/delivery/storage/storage.go
+++ b/internal/delivery/storage/storage.go
@@ -146,8 +146,9 @@ func (s *Storage) DeliverMessage(recipient string, msg *parser.Message, folder s
 		return fmt.Errorf("failed to parse message: %w", err)
 	}
 
-	// Store the message in the target database (user or role mailbox) with S3 support
-	messageID, err := parser.StoreMessagePerUserWithS3(targetDB, parsed, s.s3Storage)
+	// Store the message in the target database (user or role mailbox) with S3 support and shared blob deduplication
+	// sharedDB is already obtained earlier for domain/user operations
+	messageID, err := parser.StoreMessagePerUserWithSharedDBAndS3(sharedDB, targetDB, parsed, s.s3Storage)
 	if err != nil {
 		return fmt.Errorf("failed to store message: %w", err)
 	}

--- a/internal/server/message/message.go
+++ b/internal/server/message/message.go
@@ -528,8 +528,11 @@ func matchesHeaderOrBody(msg messageInfo, field string, searchStr string, charse
 		return false
 	}
 
+	// Get shared database for blob access
+	sharedDB := deps.GetSharedDB()
+
 	// Reconstruct message to search in headers/body
-	rawMsg, err := parser.ReconstructMessage(userDB, msg.messageID)
+	rawMsg, err := parser.ReconstructMessageWithSharedDB(sharedDB, userDB, msg.messageID)
 	if err != nil {
 		return false
 	}
@@ -573,7 +576,10 @@ func matchesHeader(msg messageInfo, fieldName string, searchStr string, charset 
 		return false
 	}
 
-	rawMsg, err := parser.ReconstructMessage(userDB, msg.messageID)
+	// Get shared database for blob access
+	sharedDB := deps.GetSharedDB()
+
+	rawMsg, err := parser.ReconstructMessageWithSharedDB(sharedDB, userDB, msg.messageID)
 	if err != nil {
 		return false
 	}
@@ -647,7 +653,10 @@ func matchesSize(msg messageInfo, size int, larger bool, userID int64, deps Serv
 		return false
 	}
 
-	rawMsg, err := parser.ReconstructMessage(userDB, msg.messageID)
+	// Get shared database for blob access
+	sharedDB := deps.GetSharedDB()
+
+	rawMsg, err := parser.ReconstructMessageWithSharedDB(sharedDB, userDB, msg.messageID)
 	if err != nil {
 		return false
 	}
@@ -689,8 +698,11 @@ func matchesSentDate(msg messageInfo, dateStr string, comparison string, userID 
 		return false
 	}
 
+	// Get shared database for blob access
+	sharedDB := deps.GetSharedDB()
+
 	// Get Date: header from message
-	rawMsg, err := parser.ReconstructMessage(userDB, msg.messageID)
+	rawMsg, err := parser.ReconstructMessageWithSharedDB(sharedDB, userDB, msg.messageID)
 	if err != nil {
 		return false
 	}
@@ -1293,9 +1305,12 @@ func HandleAppendWithReader(deps ServerDeps, reader io.Reader, conn net.Conn, ta
 		return
 	}
 
-	// Store message in database with S3 support
+	// Get shared database for blob deduplication
+	sharedDB := deps.GetSharedDB()
+
+	// Store message in database with S3 support and shared blob deduplication
 	s3Storage := deps.GetS3Storage()
-	messageID, err := parser.StoreMessagePerUserWithS3(userDB, parsed, s3Storage)
+	messageID, err := parser.StoreMessagePerUserWithSharedDBAndS3(sharedDB, userDB, parsed, s3Storage)
 	if err != nil {
 		log.Printf("Failed to store message: %v", err)
 		deps.SendResponse(conn, fmt.Sprintf("%s NO [SERVERBUG] Failed to save message", tag))
@@ -1448,9 +1463,12 @@ func HandleAppend(deps ServerDeps, conn net.Conn, tag string, parts []string, fu
 		return
 	}
 
-	// Store message in database with S3 support
+	// Get shared database for blob deduplication
+	sharedDB := deps.GetSharedDB()
+
+	// Store message in database with S3 support and shared blob deduplication
 	s3Storage := deps.GetS3Storage()
-	messageID, err := parser.StoreMessagePerUserWithS3(userDB, parsed, s3Storage)
+	messageID, err := parser.StoreMessagePerUserWithSharedDBAndS3(sharedDB, userDB, parsed, s3Storage)
 	if err != nil {
 		log.Printf("Failed to store message: %v", err)
 		deps.SendResponse(conn, fmt.Sprintf("%s NO [SERVERBUG] Failed to save message", tag))

--- a/internal/server/testing_support.go
+++ b/internal/server/testing_support.go
@@ -351,7 +351,8 @@ func InsertTestMail(t *testing.T, database interface{}, username, subject, sende
 
 	var messageID int64
 	if dbManager != nil {
-		messageID, err = parser.StoreMessagePerUser(userDB, parsed)
+		sharedDB := dbManager.GetSharedDB()
+		messageID, err = parser.StoreMessagePerUserWithSharedDB(sharedDB, userDB, parsed)
 		if err != nil {
 			t.Fatalf("Failed to store test message: %v", err)
 		}
@@ -361,7 +362,8 @@ func InsertTestMail(t *testing.T, database interface{}, username, subject, sende
 			t.Fatalf("Failed to add message to mailbox: %v", err)
 		}
 	} else {
-		messageID, err = parser.StoreMessage(userDB, parsed)
+		// Legacy monolithic database approach
+		messageID, err = parser.StoreMessageWithSharedDB(userDB, userDB, parsed)
 		if err != nil {
 			t.Fatalf("Failed to store test message: %v", err)
 		}


### PR DESCRIPTION
## 📌 Description
This PR is to move the blob table from the user database to the shared database. That will enable to deduplicate blobs globally instead of per-user deduplication.

- Closes #197 

---

## 🔍 Changes Made
- Move the blob table to shared.db
- Remove index for user database for blob table and move that to shared database
- Remove foreign key constraint 
<!-- List key changes in bullet points. -->

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
