### PR TITLE
refactor: preserve original part order in multipart/related handling …

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -1064,7 +1064,7 @@ func GetMessageParts(db *sql.DB, messageID int64) ([]map[string]interface{}, err
 		       content_transfer_encoding, charset, filename, content_id, blob_id, text_content, size_bytes
 		FROM message_parts
 		WHERE message_id = ?
-		ORDER BY part_number
+		ORDER BY id
 	`, messageID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## 📌 Description
This PR is to resolve the part number problem for a normal mail client, like Gmail

- Closes #208 

---

## 🔍 Changes Made
- Initially, part numbers were like 1-n numbers, but now it changed to for each parent, its children's parts start counting from 1.
- When fetching the mail from the database, it should now change based on the database id not the part number.( Changed this)
- Remove unused `sortMultipartRelatedChildren`and `prepareMultipartRelated` because when they are stored in the database, they are sorted, and preparation is also the same.
- Check if we have a single root multipart container. If so, skip it and use its children as IMAP top-level parts. (Updated in the fetch.go)
<!-- List key changes in bullet points. -->

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
Run the email server, connect to a few different types of MUA, and check the email by sending different type of emails.
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
