### PR TITLE
Change GitHub token for welcome action

### DIFF
--- a/.github/workflows/welcome-outside-contributors.yaml
+++ b/.github/workflows/welcome-outside-contributors.yaml
@@ -25,7 +25,7 @@ jobs:
                   - name: Welcome first-time outside commenters on issues
                     uses: actions/github-script@v7
                     with:
-                          github-token: ${{ secrets.WELCOME_BOT_PAT || github.token }}
+                          github-token: ${{ secrets.SILVER_BOT_TOKEN || github.token }}
                           script: |
                                 const issueNumber = context.payload.issue.number;
                                 const login = context.payload.comment.user.login;


### PR DESCRIPTION
Change the GitHub token env variable name. Because for the security version update workflow, the silver bot token is added using this variable name.