### PR TITLE
fix(auth): reject login attempts with bare usernames and enforce domain validation

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -194,12 +194,12 @@ func extractApplicationIDFromThunderLogs() (string, error) {
 		return "", fmt.Errorf("docker logs failed: %w", err)
 	}
 
-	// Search for "DEVELOP_APP_ID:" in logs
-	// Log format: [INFO] DEVELOP_APP_ID: 019cdc47-3537-74ee-951e-3f50e48786ab
+	// Search for "CONSOLE_APP_ID:" in logs
+	// Log format: [INFO] CONSOLE_APP_ID: 019cdc47-3537-74ee-951e-3f50e48786ab
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
-		// Look for line containing DEVELOP_APP_ID (case-insensitive)
-		if strings.Contains(line, "DEVELOP_APP_ID") || strings.Contains(line, "develop_app_id") {
+		// Look for line containing CONSOLE_APP_ID (case-insensitive)
+		if strings.Contains(line, "CONSOLE_APP_ID") || strings.Contains(line, "console_app_id") {
 			match := uuidRegex.FindString(line)
 			if match != "" {
 				log.Printf("✓ Application ID extracted from thunder logs: %s", match)

--- a/internal/delivery/groupresolver/groupresolver.go
+++ b/internal/delivery/groupresolver/groupresolver.go
@@ -325,7 +325,7 @@ type userRecord struct {
 func (gr *GroupResolver) fetchUserByID(assertion, userID string) (*userRecord, error) {
 	type userResponse struct {
 		ID                  string `json:"id"`
-		OrganizationUnit    string `json:"organizationUnit"`
+		OrganizationUnit    string `json:"ouId"`
 		OrganizationUnitAlt string `json:"organization_unit"`
 		Username            string `json:"username"`
 		UserName            string `json:"userName"`

--- a/internal/delivery/groupresolver/groupresolver_test.go
+++ b/internal/delivery/groupresolver/groupresolver_test.go
@@ -177,7 +177,7 @@ func TestGroupMemberResolution(t *testing.T) {
 		case "/users/user-1":
 			resp := map[string]interface{}{
 				"id":               "user-1",
-				"organizationUnit": "ou-1",
+				"ouId":             "ou-1",
 				"attributes": map[string]string{
 					"username": "alice",
 				},
@@ -187,7 +187,7 @@ func TestGroupMemberResolution(t *testing.T) {
 		case "/users/user-2":
 			resp := map[string]interface{}{
 				"id":               "user-2",
-				"organizationUnit": "ou-2",
+				"ouId":             "ou-2",
 				"attributes": map[string]string{
 					"username": "bob",
 				},

--- a/internal/delivery/lmtp/session_test.go
+++ b/internal/delivery/lmtp/session_test.go
@@ -961,8 +961,8 @@ func TestGroupEmailDelivery(t *testing.T) {
 
 		case "/users/user-1":
 			_ = writeJSON(w, map[string]any{
-				"id":               "user-1",
-				"organizationUnit": "ou-1",
+				"id":   "user-1",
+				"ouId": "ou-1",
 				"attributes": map[string]string{
 					"username": "alice",
 				},
@@ -970,8 +970,8 @@ func TestGroupEmailDelivery(t *testing.T) {
 
 		case "/users/user-2":
 			_ = writeJSON(w, map[string]any{
-				"id":               "user-2",
-				"organizationUnit": "ou-2",
+				"id":   "user-2",
+				"ouId": "ou-2",
 				"attributes": map[string]string{
 					"username": "bob",
 				},

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -530,11 +530,6 @@ func authenticateUser(deps ServerDeps, conn net.Conn, tag string, username strin
 		}
 
 		email := loginEmail
-		if email == "" {
-			log.Printf("LOGIN: unable to resolve mailbox email from login '%s'", loginEmail)
-			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
-			return
-		}
 
 		actualUsername := deps.ExtractUsername(email)
 

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -486,7 +486,7 @@ func authenticateUser(deps ServerDeps, conn net.Conn, tag string, username strin
 		var authResp struct {
 			ID               string `json:"id"`
 			Type             string `json:"type"`
-			OrganizationUnit string `json:"organization_unit"`
+			OrganizationUnit string `json:"ouId"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
 			log.Printf("LOGIN: failed to decode auth response: %v", err)

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -251,9 +251,16 @@ func HandleAuthenticate(deps ServerDeps, conn net.Conn, tag string, parts []stri
 			return
 		}
 
-		accessToken, _, _, err := oauthbearer.ParseInitialClientResponseDetails(authData)
+		accessToken, _, saslUser, err := oauthbearer.ParseInitialClientResponseDetails(authData)
 		if err != nil {
 			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Invalid OAuth payload", tag))
+			return
+		}
+
+		saslUserEmail := normalizeEmail(saslUser)
+		if saslUserEmail == "" {
+			log.Printf("OAUTHBEARER: rejected non-email SASL user field: %q", saslUser)
+			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
 			return
 		}
 
@@ -306,7 +313,14 @@ func HandleAuthenticate(deps ServerDeps, conn net.Conn, tag string, parts []stri
 		if email == "" && cfg.Domain != "" && !strings.Contains(identity, "@") {
 			email = strings.TrimSpace(identity) + "@" + strings.Trim(strings.TrimSpace(cfg.Domain), ".")
 		}
+		email = normalizeEmail(email)
 		if email == "" {
+			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
+			return
+		}
+
+		if !strings.EqualFold(saslUserEmail, email) {
+			log.Printf("OAUTHBEARER: SASL user %q does not match resolved mailbox email %q", saslUserEmail, email)
 			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
 			return
 		}

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -402,6 +402,13 @@ func HandleLogout(deps ServerDeps, conn net.Conn, tag string) {
 
 // Extract common authentication logic
 func authenticateUser(deps ServerDeps, conn net.Conn, tag string, username string, password string, state *models.ClientState) {
+	loginEmail := normalizeEmail(username)
+	if loginEmail == "" {
+		log.Printf("LOGIN: rejected non-email login identity: %q", username)
+		deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
+		return
+	}
+
 	// Load authentication service configuration
 	cfg, err := conf.LoadConfig()
 	if err != nil {
@@ -416,9 +423,9 @@ func authenticateUser(deps ServerDeps, conn net.Conn, tag string, username strin
 	}
 
 	// Determine the username to use for authentication
-	authUsername := deps.ExtractUsername(username)
+	authUsername := deps.ExtractUsername(loginEmail)
 	if authUsername == "" {
-		authUsername = username
+		authUsername = loginEmail
 	}
 
 	// Prepare JSON body
@@ -480,39 +487,37 @@ func authenticateUser(deps ServerDeps, conn net.Conn, tag string, username strin
 
 		log.Printf("Accepting login for user: %s (type=%s)", username, authResp.Type)
 
-		derivedDomain := ""
+		parts := strings.SplitN(loginEmail, "@", 2)
+		loginDomain := strings.Trim(strings.TrimSpace(parts[1]), ".")
+
+		expectedDomain := ""
 		if authResp.OrganizationUnit != "" {
-			if strings.Contains(username, "@") {
-				derivedDomain = resolveDomainFromOrganizationUnit(cfg.AuthServerURL, authResp.OrganizationUnit, authUsername, password)
-				if derivedDomain == "" {
-					log.Printf("LOGIN: unable to resolve OU-derived domain for login '%s'", username)
-					deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
-					return
-				}
+			derivedDomain := resolveDomainFromOrganizationUnit(cfg.AuthServerURL, authResp.OrganizationUnit, authUsername, password)
+			expectedDomain = strings.Trim(strings.TrimSpace(derivedDomain), ".")
+		}
 
-				loginEmail := normalizeEmail(username)
-				if loginEmail == "" {
-					log.Printf("LOGIN: invalid login identity format: %s", username)
-					deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
-					return
-				}
-
-				parts := strings.SplitN(loginEmail, "@", 2)
-				loginDomain := strings.Trim(strings.TrimSpace(parts[1]), ".")
-				expectedDomain := strings.Trim(strings.TrimSpace(derivedDomain), ".")
-				if !strings.EqualFold(loginDomain, expectedDomain) {
-					log.Printf("LOGIN: login domain '%s' does not match OU-derived domain '%s' for user '%s'", loginDomain, expectedDomain, username)
-					deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
-					return
-				}
-			} else if !strings.Contains(authResp.ID, "@") {
-				derivedDomain = resolveDomainFromOrganizationUnit(cfg.AuthServerURL, authResp.OrganizationUnit, authUsername, password)
+		if expectedDomain == "" {
+			if idEmail := normalizeEmail(authResp.ID); idEmail != "" {
+				idParts := strings.SplitN(idEmail, "@", 2)
+				expectedDomain = strings.Trim(strings.TrimSpace(idParts[1]), ".")
 			}
 		}
 
-		email := resolveMailboxEmail(username, authResp.ID, derivedDomain)
+		if expectedDomain == "" {
+			log.Printf("LOGIN: unable to resolve expected IdP domain for login '%s'", loginEmail)
+			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
+			return
+		}
+
+		if !strings.EqualFold(loginDomain, expectedDomain) {
+			log.Printf("LOGIN: login domain '%s' does not match OU-derived domain '%s' for user '%s'", loginDomain, expectedDomain, loginEmail)
+			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
+			return
+		}
+
+		email := loginEmail
 		if email == "" {
-			log.Printf("LOGIN: unable to resolve mailbox email from login '%s' and auth id '%s'", username, authResp.ID)
+			log.Printf("LOGIN: unable to resolve mailbox email from login '%s'", loginEmail)
 			deps.SendResponse(conn, fmt.Sprintf("%s NO [AUTHENTICATIONFAILED] Authentication failed", tag))
 			return
 		}

--- a/internal/server/auth/authenticate_integration_test.go
+++ b/internal/server/auth/authenticate_integration_test.go
@@ -261,9 +261,9 @@ auth_server_url: %s
 	t.Logf("Response with domain in username: %s", response)
 }
 
-// TestAuthenticatePlain_UsernameWithoutDomain tests authentication with bare username
+// TestAuthenticatePlain_UsernameWithoutDomain rejects bare username credentials.
 func TestAuthenticatePlain_UsernameWithoutDomain(t *testing.T) {
-	// Username without @ should have configured domain appended
+	// Bare usernames must be rejected.
 	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -317,7 +317,9 @@ auth_server_url: %s
 	s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE", "PLAIN"}, state)
 
 	response = conn.GetWrittenData()
-	t.Logf("Response without domain in username: %s", response)
+	if !strings.Contains(response, "A001 NO [AUTHENTICATIONFAILED]") {
+		t.Fatalf("Expected AUTHENTICATIONFAILED for bare username, got: %s", response)
+	}
 }
 
 // TestAuthenticatePlain_AuthenticationFailure tests failed authentication

--- a/internal/server/auth/authenticate_oauth_test.go
+++ b/internal/server/auth/authenticate_oauth_test.go
@@ -96,6 +96,33 @@ func TestAuthenticateOAuth_InvalidTokenRejected(t *testing.T) {
 	}
 }
 
+func TestAuthenticateOAuth_RejectsBareUsernameInSASLUser(t *testing.T) {
+	tmpDir := t.TempDir()
+	mustWriteConfig(t, tmpDir, "https://issuer.example.com", "https://jwks.example.com/jwks", []string{"raven-imap"})
+
+	restore := mustChdir(t, tmpDir)
+	defer restore()
+
+	s, cleanup := server.SetupTestServer(t)
+	defer cleanup()
+
+	payload := fmt.Sprintf("user=user2\x01auth=Bearer %s\x01\x01", "not-a-jwt")
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+
+	conn := server.NewMockTLSConn()
+	state := &models.ClientState{Authenticated: false}
+
+	s.HandleAuthenticate(conn, "A903A", []string{"A903A", "AUTHENTICATE", "XOAUTH2", encoded}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A903A NO [AUTHENTICATIONFAILED] Authentication failed") {
+		t.Fatalf("expected auth failure, got: %s", response)
+	}
+	if state.Authenticated {
+		t.Fatal("expected unauthenticated state")
+	}
+}
+
 func TestAuthenticateOAuth_SuccessWithJWKS(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -139,7 +166,7 @@ func TestAuthenticateOAuth_SuccessWithJWKS(t *testing.T) {
 		t.Fatalf("failed to sign token: %v", err)
 	}
 
-	payload := fmt.Sprintf("user=user2\x01auth=Bearer %s\x01\x01", token)
+	payload := fmt.Sprintf("user=user2@example.com\x01auth=Bearer %s\x01\x01", token)
 	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
 
 	conn := server.NewMockTLSConn()
@@ -156,6 +183,66 @@ func TestAuthenticateOAuth_SuccessWithJWKS(t *testing.T) {
 	}
 	if state.Email != "user2@example.com" {
 		t.Fatalf("unexpected state email: %q", state.Email)
+	}
+}
+
+func TestAuthenticateOAuth_RejectsSASLUserEmailMismatch(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate rsa key: %v", err)
+	}
+
+	issuer := "https://issuer.example.com"
+	aud := "raven-imap"
+
+	jwkN, jwkE := rsaPublicJWK(t, &priv.PublicKey)
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{{
+				"kty": "RSA",
+				"kid": "kid-auth-2",
+				"n":   jwkN,
+				"e":   jwkE,
+			}},
+		})
+	}))
+	defer jwksServer.Close()
+
+	tmpDir := t.TempDir()
+	mustWriteConfig(t, tmpDir, issuer, jwksServer.URL, []string{aud})
+
+	restore := mustChdir(t, tmpDir)
+	defer restore()
+
+	s, cleanup := server.SetupTestServer(t)
+	defer cleanup()
+
+	token, err := signToken(priv, "kid-auth-2", jwt.MapClaims{
+		"iss":      issuer,
+		"aud":      []string{aud},
+		"exp":      time.Now().Add(2 * time.Minute).Unix(),
+		"username": "user2",
+		"email":    "user2@silver.example.com",
+		"sub":      "subject-2",
+	})
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	payload := fmt.Sprintf("user=user2@example.com\x01auth=Bearer %s\x01\x01", token)
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+
+	conn := server.NewMockTLSConn()
+	state := &models.ClientState{Authenticated: false}
+
+	s.HandleAuthenticate(conn, "A905", []string{"A905", "AUTHENTICATE", "OAUTHBEARER", encoded}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A905 NO [AUTHENTICATIONFAILED] Authentication failed") {
+		t.Fatalf("expected auth failure, got: %s", response)
+	}
+	if state.Authenticated {
+		t.Fatal("expected unauthenticated state")
 	}
 }
 

--- a/internal/server/auth/authenticateuser_test.go
+++ b/internal/server/auth/authenticateuser_test.go
@@ -17,7 +17,7 @@ import (
 
 func writeAuthOK(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{"id":"testuser@example.com","type":"test-user","organization_unit":""}`))
+	_, _ = w.Write([]byte(`{"id":"testuser@example.com","type":"test-user","ouId":""}`))
 }
 
 // setupTestConfig creates a temporary config file and returns cleanup function
@@ -243,7 +243,7 @@ func TestAuthenticateUser_SubdomainEmailFromIDP(t *testing.T) {
 	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id":"user2@silver.example.com","type":"test-user","organization_unit":"silver"}`))
+		_, _ = w.Write([]byte(`{"id":"user2@silver.example.com","type":"test-user","ouId":"silver"}`))
 	}))
 	defer authServer.Close()
 
@@ -284,7 +284,7 @@ func TestAuthenticateUser_SubdomainEmailFromOrgUnitHierarchy(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","organization_unit":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -394,7 +394,7 @@ func TestAuthenticateUser_UsernameWithDomainMismatchFromOrgUnit(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","organization_unit":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -463,7 +463,7 @@ func TestAuthenticateUser_UsernameWithDomainMatchesOrgUnit(t *testing.T) {
 		case "/auth/credentials/authenticate":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","organization_unit":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
+			_, _ = w.Write([]byte(`{"id":"019cf0a6-114a-7dad-bea1-9a36bc728ece","type":"silveruser","ouId":"019cf0a5-4109-79ac-857b-07fc7b5c19ac"}`))
 		case "/flow/execute":
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {

--- a/internal/server/auth/authenticateuser_test.go
+++ b/internal/server/auth/authenticateuser_test.go
@@ -97,7 +97,7 @@ func TestAuthenticateUser_ConfigLoadError(t *testing.T) {
 	state := &models.ClientState{}
 
 	// Try to login
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -132,7 +132,7 @@ func TestAuthenticateUser_MissingDomain(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -158,7 +158,7 @@ func TestAuthenticateUser_MissingAuthServerURL(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -204,7 +204,7 @@ func TestAuthenticateUser_UsernameWithDomain(t *testing.T) {
 	}
 }
 
-// TestAuthenticateUser_UsernameWithoutDomain tests authentication with bare username
+// TestAuthenticateUser_UsernameWithoutDomain rejects bare username logins.
 func TestAuthenticateUser_UsernameWithoutDomain(t *testing.T) {
 	// Create mock auth server
 	authServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -227,15 +227,14 @@ func TestAuthenticateUser_UsernameWithoutDomain(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	// Login with bare username (domain should come from IdP email identity)
+	// Login with bare username must be rejected.
 	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "bareuser", "password"}, state)
 
 	response := conn.GetWrittenData()
 	t.Logf("Response: %s", response)
 
-	// Successful login proves domain is resolved without relying on config domain.
-	if strings.Contains(response, "OK") {
-		t.Log("Authentication succeeded as expected")
+	if !strings.Contains(response, "NO [AUTHENTICATIONFAILED]") {
+		t.Fatalf("Expected bare username authentication failure, got: %s", response)
 	}
 }
 
@@ -262,7 +261,7 @@ func TestAuthenticateUser_SubdomainEmailFromIDP(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2", "password"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@silver.example.com", "password"}, state)
 
 	response := conn.GetWrittenData()
 	if !strings.Contains(response, "A001 OK") {
@@ -368,7 +367,7 @@ func TestAuthenticateUser_SubdomainEmailFromOrgUnitHierarchy(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2", "password"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user2@silver.example.com", "password"}, state)
 
 	response := conn.GetWrittenData()
 	if !strings.Contains(response, "A001 OK") {
@@ -539,7 +538,7 @@ func TestAuthenticateUser_AuthServerUnavailable(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -583,7 +582,7 @@ func TestAuthenticateUser_AuthenticationSuccess(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "testuser", "testpass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "testuser@example.com", "testpass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -629,7 +628,7 @@ func TestAuthenticateUser_AuthenticationFailure(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "wrongpass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "wrongpass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -686,7 +685,7 @@ func TestAuthenticateUser_VariousStatusCodes(t *testing.T) {
 			conn := server.NewMockTLSConn()
 			state := &models.ClientState{}
 
-			s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+			s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 			response := conn.GetWrittenData()
 
@@ -729,7 +728,7 @@ func TestAuthenticateUser_TLSConnectionCapabilities(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -774,7 +773,7 @@ func TestAuthenticateUser_PlainConnectionCapabilities(t *testing.T) {
 	state := &models.ClientState{}
 
 	// This will fail due to TLS requirement in HandleLogin, but demonstrates the test structure
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user", "pass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "user@example.com", "pass"}, state)
 
 	response := conn.GetWrittenData()
 	t.Logf("Response on plain connection: %s", response)
@@ -806,7 +805,7 @@ func TestAuthenticateUser_RoleAssignmentsSuccess(t *testing.T) {
 	conn := server.NewMockTLSConn()
 	state := &models.ClientState{}
 
-	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "testuser", "testpass"}, state)
+	s.HandleLogin(conn, "A001", []string{"A001", "LOGIN", "testuser@example.com", "testpass"}, state)
 
 	response := conn.GetWrittenData()
 
@@ -823,11 +822,12 @@ func TestAuthenticateUser_UsernameExtraction(t *testing.T) {
 	testCases := []struct {
 		name     string
 		username string
+		expectNo bool
 	}{
-		{"Simple username", "john"},
-		{"Username with dots", "john.doe"},
-		{"Username with numbers", "user123"},
-		{"Full email", "user@example.com"},
+		{"Simple username", "john", true},
+		{"Username with dots", "john.doe", true},
+		{"Username with numbers", "user123", true},
+		{"Full email", "user@example.com", false},
 	}
 
 	for _, tc := range testCases {
@@ -856,7 +856,13 @@ func TestAuthenticateUser_UsernameExtraction(t *testing.T) {
 			response := conn.GetWrittenData()
 			t.Logf("Response for username '%s': %s", tc.username, response)
 
-			if strings.Contains(response, "OK") {
+			if tc.expectNo {
+				if !strings.Contains(response, "NO [AUTHENTICATIONFAILED]") {
+					t.Fatalf("Expected non-email login rejection for %q, got: %s", tc.username, response)
+				}
+			}
+
+			if !tc.expectNo && strings.Contains(response, "OK") {
 				t.Logf("Username extraction succeeded for: %s", tc.username)
 			}
 		})

--- a/internal/server/auth/login_test.go
+++ b/internal/server/auth/login_test.go
@@ -262,6 +262,21 @@ func TestLoginCommand_ResponseFormat(t *testing.T) {
 	}
 }
 
+func TestLoginCommand_RejectsUsernameWithoutDomain(t *testing.T) {
+	s, cleanup := server.SetupTestServer(t)
+	defer cleanup()
+
+	conn := server.NewMockTLSConn()
+	state := &models.ClientState{Authenticated: false}
+
+	s.HandleLogin(conn, "A018", []string{"A018", "LOGIN", "user1", "password123"}, state)
+
+	response := conn.GetWrittenData()
+	if !strings.Contains(response, "A018 NO [AUTHENTICATIONFAILED]") {
+		t.Fatalf("Expected AUTHENTICATIONFAILED for non-email username, got: %s", response)
+	}
+}
+
 // TestLoginCommand_MultipleAttempts tests multiple LOGIN attempts
 func TestLoginCommand_MultipleAttempts(t *testing.T) {
 	s, cleanup := server.SetupTestServer(t)

--- a/internal/socketmap/thunder/auth.go
+++ b/internal/socketmap/thunder/auth.go
@@ -20,7 +20,7 @@ var (
 func Authenticate(host, port string, tokenRefreshSeconds int) (*Auth, error) {
 	log.Printf("  ┌─ Thunder Authentication ─────────")
 
-	// Step 1: Get DEVELOP App ID using shared utility
+	// Step 1: Get Console App ID using shared utility
 	// This will try environment variables first, then fall back to extracting from thunder logs
 	developAppID, err := conf.GetApplicationID()
 	if err != nil {
@@ -33,7 +33,7 @@ func Authenticate(host, port string, tokenRefreshSeconds int) (*Auth, error) {
 		log.Printf("  │ To fix this issue:")
 		log.Printf("  │ 1. Check thunder-setup logs: docker logs thunder-setup")
 		log.Printf("  │ 2. Extract App ID manually and set environment:")
-		log.Printf("  │    export THUNDER_DEVELOP_APP_ID=$(docker logs thunder-setup 2>&1 | grep 'DEVELOP_APP_ID:' | grep -o '[a-f0-9-]\\{36\\}')")
+		log.Printf(`  │    export THUNDER_DEVELOP_APP_ID=$(docker logs thunder-setup 2>&1 | grep 'CONSOLE_APP_ID:' | grep -o '[a-f0-9-]\{36\}')`)
 		log.Printf("  │ 3. Or if running in Docker, mount the Docker socket:")
 		log.Printf("  │    volumes: ['/var/run/docker.sock:/var/run/docker.sock']")
 		log.Printf("  └───────────────────────────────────")

--- a/internal/socketmap/thunder/group.go
+++ b/internal/socketmap/thunder/group.go
@@ -53,19 +53,12 @@ func ValidateGroupAddress(email, host, port string, tokenRefreshSeconds int) (bo
 	log.Printf("      │ OU ID: %s", ouID)
 
 	client := GetHTTPClient()
-	escapedGroupName := escapeFilterValue(groupName)
-	filter := fmt.Sprintf("name eq \"%s\"", escapedGroupName)
-
 	baseURL := fmt.Sprintf("https://%s:%s/groups", host, port)
 	req, err := http.NewRequest("GET", baseURL, nil)
 	if err != nil {
 		log.Printf("      │ ✗ Failed to create request: %v", err)
 		return false, err
 	}
-
-	q := req.URL.Query()
-	q.Add("filter", filter)
-	req.URL.RawQuery = q.Encode()
 
 	req.Header.Set("Authorization", "Bearer "+auth.BearerToken)
 	req.Header.Set("Content-Type", "application/json")
@@ -102,7 +95,7 @@ func ValidateGroupAddress(email, host, port string, tokenRefreshSeconds int) (bo
 	}
 
 	for _, group := range groupsResp.Groups {
-		if group.OrganizationUnitID == ouID && group.Name == groupName {
+		if group.OrganizationUnitID == ouID && strings.EqualFold(group.Name, groupName) {
 			log.Printf("      │ ✓ Group found and OU matches")
 			return true, nil
 		}

--- a/internal/socketmap/thunder/types.go
+++ b/internal/socketmap/thunder/types.go
@@ -44,7 +44,7 @@ type UsersResponse struct {
 // User represents a Thunder user
 type User struct {
 	ID               string                 `json:"id"`
-	OrganizationUnit string                 `json:"organizationUnit"`
+	OrganizationUnit string                 `json:"ouId"`
 	Type             string                 `json:"type"`
 	Attributes       map[string]interface{} `json:"attributes"`
 }
@@ -62,5 +62,5 @@ type GroupsResponse struct {
 type Group struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
-	OrganizationUnitID string `json:"organizationUnitId"`
+	OrganizationUnitID string `json:"ouId"`
 }

--- a/test/helpers/server.go
+++ b/test/helpers/server.go
@@ -77,7 +77,7 @@ func StartTestIMAPServer(t *testing.T, dbManager *db.DBManager) *TestIMAPServer 
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, `{"id":%q,"type":"test-user","organization_unit":""}`,
+		_, _ = fmt.Fprintf(w, `{"id":%q,"type":"test-user","ouId":""}`,
 			emailID,
 		)
 	})


### PR DESCRIPTION
## 📌 Description
This PR is to enforce to send email address when logging in. 
Did update a few things related to Thunder version upgrade.
<!-- Provide a clear, concise description of what this PR does. -->

- Closes #267 

---

## 🔍 Changes Made
- Update the auth.go for only accept email address not the username in the login process
- Now the response contain `ouId` instead of `organizationId` or any other variation.
- Now the Develop app is removed and instead that it contains console app. 
<!-- List key changes in bullet points. -->

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers

<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
