### PR TITLE
271 feature support role based email validation in socketmap user exist check

### DIFF
--- a/config/delivery.yaml
+++ b/config/delivery.yaml
@@ -55,9 +55,16 @@ logging:
 # S3-Compatible Blob Storage Configuration
 blob_storage:
   enabled: true
-  endpoint: "http://localhost:8333"  # SeaweedFS endpoint
+  endpoint: "http://localhost:8333" # SeaweedFS endpoint
   region: "us-east-1"
   bucket: "email-attachments"
   access_key: "your-access-key"
   secret_key: "your-secret-key"
-  timeout: 30  # seconds
+  timeout: 30 # seconds
+
+# Socket map configuration for user lookups
+socketmap:
+  enabled: true
+  network: "tcp"
+  address: "raven:9100"
+  timeout_seconds: 2

--- a/internal/db/db_manager.go
+++ b/internal/db/db_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -95,6 +96,7 @@ func (m *DBManager) GetUserDB(email string) (*sql.DB, error) {
 
 	return db, nil
 }
+
 // initSharedDB initializes the shared database
 func (m *DBManager) initSharedDB() error {
 	sharedPath := filepath.Join(m.basePath, "shared.db")
@@ -130,7 +132,7 @@ func (m *DBManager) initSharedDB() error {
 func (m *DBManager) initUserDB(db *sql.DB) error {
 	// Create user tables
 	// Note: blobs table is now in shared database for cross-user deduplication
-	
+
 	if err := createMailboxesTablePerUser(db); err != nil {
 		return fmt.Errorf("failed to create mailboxes table: %v", err)
 	}
@@ -186,8 +188,14 @@ func (m *DBManager) initUserDB(db *sql.DB) error {
 
 // getUserDBPath returns the file path for a user's database
 func (m *DBManager) getUserDBPath(email string) string {
+	if strings.HasSuffix(email, ".db") {
+		// Preserve explicit mailbox identity paths (for example role_<name>@<domain>.db).
+		return filepath.Join(m.basePath, email)
+	}
+
 	return filepath.Join(m.basePath, fmt.Sprintf("user_%s.db", email))
 }
+
 // Close closes all database connections
 func (m *DBManager) Close() error {
 	var lastErr error

--- a/internal/db/db_manager_test.go
+++ b/internal/db/db_manager_test.go
@@ -125,7 +125,7 @@ func TestGetUserDB_RoleMailboxIdentityPath(t *testing.T) {
 	}
 	defer func() { _ = manager.Close() }()
 
-	identity := "role_testrole@aravindahwk.org.db"
+	identity := "role_testrole@testorg.example.db"
 	userDB, err := manager.GetUserDB(identity)
 	if err != nil {
 		t.Fatalf("GetUserDB failed: %v", err)

--- a/internal/db/db_manager_test.go
+++ b/internal/db/db_manager_test.go
@@ -112,6 +112,39 @@ func TestGetUserDB(t *testing.T) {
 	}
 }
 
+func TestGetUserDB_RoleMailboxIdentityPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db_manager_test_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	manager, err := NewDBManager(tmpDir)
+	if err != nil {
+		t.Fatalf("NewDBManager failed: %v", err)
+	}
+	defer func() { _ = manager.Close() }()
+
+	identity := "role_testrole@aravindahwk.org.db"
+	userDB, err := manager.GetUserDB(identity)
+	if err != nil {
+		t.Fatalf("GetUserDB failed: %v", err)
+	}
+	if userDB == nil {
+		t.Fatal("Expected non-nil user database")
+	}
+
+	roleDBPath := filepath.Join(tmpDir, identity)
+	if _, err := os.Stat(roleDBPath); os.IsNotExist(err) {
+		t.Errorf("Expected role database file to be created at %s", roleDBPath)
+	}
+
+	legacyPath := filepath.Join(tmpDir, fmt.Sprintf("user_%s.db", identity))
+	if _, err := os.Stat(legacyPath); err == nil {
+		t.Errorf("Did not expect legacy user-prefixed path to exist: %s", legacyPath)
+	}
+}
+
 func TestGetUserDB_Caching(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "db_manager_test_*")
 	if err != nil {

--- a/internal/delivery/config/config.go
+++ b/internal/delivery/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	LMTP        LMTPConfig         `yaml:"lmtp"`
 	Database    DatabaseConfig     `yaml:"database"`
 	Delivery    DeliveryConfig     `yaml:"delivery"`
+	Socketmap   SocketmapConfig    `yaml:"socketmap"`
 	Logging     LoggingConfig      `yaml:"logging"`
 	BlobStorage blobstorage.Config `yaml:"blob_storage"`
 	IDPBaseURL  string             // IDP base URL (loaded from raven.yaml auth_server_url)
@@ -46,6 +47,14 @@ type DeliveryConfig struct {
 	RejectUnknownUser bool     `yaml:"reject_unknown_user"` // Reject messages for unknown users
 }
 
+// SocketmapConfig controls optional socketmap identity resolution in LMTP.
+type SocketmapConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	Network        string `yaml:"network"`         // tcp or unix
+	Address        string `yaml:"address"`         // host:port for tcp, socket path for unix
+	TimeoutSeconds int    `yaml:"timeout_seconds"` // Connection/read/write timeout
+}
+
 // LoggingConfig holds logging configuration
 type LoggingConfig struct {
 	Level  string `yaml:"level"`  // log level: debug, info, warn, error
@@ -72,6 +81,12 @@ func DefaultConfig() *Config {
 			QuotaLimit:        1073741824, // 1GB
 			AllowedDomains:    []string{},
 			RejectUnknownUser: false,
+		},
+		Socketmap: SocketmapConfig{
+			Enabled:        false,
+			Network:        "tcp",
+			Address:        "",
+			TimeoutSeconds: 2,
 		},
 		Logging: LoggingConfig{
 			Level:  "info",
@@ -197,6 +212,20 @@ func (c *Config) Validate() error {
 
 	if c.Delivery.QuotaEnabled && c.Delivery.QuotaLimit <= 0 {
 		return fmt.Errorf("quota_limit must be positive when quota is enabled")
+	}
+
+	if c.Socketmap.Enabled {
+		if c.Socketmap.Network != "tcp" && c.Socketmap.Network != "unix" {
+			return fmt.Errorf("socketmap network must be tcp or unix")
+		}
+
+		if c.Socketmap.Address == "" {
+			return fmt.Errorf("socketmap address cannot be empty when enabled")
+		}
+
+		if c.Socketmap.TimeoutSeconds <= 0 {
+			return fmt.Errorf("socketmap timeout_seconds must be positive when enabled")
+		}
 	}
 
 	// Validate logging config

--- a/internal/delivery/lmtp/session.go
+++ b/internal/delivery/lmtp/session.go
@@ -23,8 +23,10 @@ type Session struct {
 	storage       *storage.Storage
 	config        *config.Config
 	groupResolver *groupresolver.GroupResolver
+	identityRes   identityResolver
 	mailFrom      string
 	recipients    []string
+	recipientMap  map[string]string
 	helo          string
 }
 
@@ -37,7 +39,9 @@ func NewSession(conn net.Conn, stor *storage.Storage, cfg *config.Config, gr *gr
 		storage:       stor,
 		config:        cfg,
 		groupResolver: gr,
+		identityRes:   newIdentityResolver(cfg),
 		recipients:    make([]string, 0),
+		recipientMap:  make(map[string]string),
 	}
 }
 
@@ -221,7 +225,15 @@ func (s *Session) handleRCPT(args string) error {
 		if len(s.recipients) >= s.config.LMTP.MaxRecipients {
 			return s.sendResponse(452, "Too many recipients")
 		}
+
+		mailboxIdentity, resolveErr := s.resolveMailboxIdentity(recipient)
+		if resolveErr != nil {
+			log.Printf("Warning: failed to resolve mailbox identity for %s: %v", recipient, resolveErr)
+			mailboxIdentity = recipient
+		}
+
 		s.recipients = append(s.recipients, recipient)
+		s.recipientMap[recipient] = mailboxIdentity
 	}
 
 	return s.sendResponse(250, "2.1.5 Recipient OK")
@@ -351,9 +363,17 @@ func (s *Session) handleDATA() error {
 		}
 	}
 
-	// Deliver to each recipient (LMTP requires per-recipient response)
+	// Deliver to each envelope recipient (LMTP requires per-recipient response)
 	folder := s.config.Delivery.DefaultFolder
-	results := s.storage.DeliverToMultipleRecipients(s.recipients, msg, folder)
+	results := make(map[string]error, len(s.recipients))
+	for _, recipient := range s.recipients {
+		targetRecipient := recipient
+		if mappedRecipient, ok := s.recipientMap[recipient]; ok && mappedRecipient != "" {
+			targetRecipient = mappedRecipient
+		}
+
+		results[recipient] = s.storage.DeliverMessage(targetRecipient, msg, folder)
+	}
 
 	// Send per-recipient responses
 	for _, recipient := range s.recipients {
@@ -369,6 +389,7 @@ func (s *Session) handleDATA() error {
 	// Reset session state
 	s.mailFrom = ""
 	s.recipients = make([]string, 0)
+	s.recipientMap = make(map[string]string)
 
 	return nil
 }
@@ -377,7 +398,24 @@ func (s *Session) handleDATA() error {
 func (s *Session) handleRSET() error {
 	s.mailFrom = ""
 	s.recipients = make([]string, 0)
+	s.recipientMap = make(map[string]string)
 	return s.sendResponse(250, "Reset state")
+}
+
+func (s *Session) resolveMailboxIdentity(recipient string) (string, error) {
+	if s.identityRes == nil {
+		return recipient, nil
+	}
+
+	identity, err := s.identityRes(recipient)
+	if err != nil {
+		return "", err
+	}
+	if identity == "" {
+		return recipient, nil
+	}
+
+	return identity, nil
 }
 
 // handleNOOP handles the NOOP command

--- a/internal/delivery/lmtp/session.go
+++ b/internal/delivery/lmtp/session.go
@@ -47,6 +47,10 @@ func NewSession(conn net.Conn, stor *storage.Storage, cfg *config.Config, gr *gr
 
 // Handle handles the LMTP session
 func (s *Session) Handle() error {
+	if s.identityRes != nil {
+		defer func() { _ = s.identityRes.Close() }()
+	}
+
 	// Set connection timeout
 	if s.config.LMTP.Timeout > 0 {
 		timeout := time.Duration(s.config.LMTP.Timeout) * time.Second
@@ -366,13 +370,21 @@ func (s *Session) handleDATA() error {
 	// Deliver to each envelope recipient (LMTP requires per-recipient response)
 	folder := s.config.Delivery.DefaultFolder
 	results := make(map[string]error, len(s.recipients))
+	deliveredTargets := make(map[string]error, len(s.recipients))
 	for _, recipient := range s.recipients {
 		targetRecipient := recipient
 		if mappedRecipient, ok := s.recipientMap[recipient]; ok && mappedRecipient != "" {
 			targetRecipient = mappedRecipient
 		}
 
-		results[recipient] = s.storage.DeliverMessage(targetRecipient, msg, folder)
+		if err, alreadyDelivered := deliveredTargets[targetRecipient]; alreadyDelivered {
+			results[recipient] = err
+			continue
+		}
+
+		err := s.storage.DeliverMessage(targetRecipient, msg, folder)
+		deliveredTargets[targetRecipient] = err
+		results[recipient] = err
 	}
 
 	// Send per-recipient responses
@@ -407,7 +419,7 @@ func (s *Session) resolveMailboxIdentity(recipient string) (string, error) {
 		return recipient, nil
 	}
 
-	identity, err := s.identityRes(recipient)
+	identity, err := s.identityRes.Resolve(recipient)
 	if err != nil {
 		return "", err
 	}

--- a/internal/delivery/lmtp/session_test.go
+++ b/internal/delivery/lmtp/session_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -387,6 +388,86 @@ func TestSession_HandleRCPT(t *testing.T) {
 
 	if session.recipients[0] != "recipient@example.com" {
 		t.Errorf("Expected recipient 'recipient@example.com', got %s", session.recipients[0])
+	}
+}
+
+func TestSession_HandleRCPT_StoresResolvedMailboxIdentity(t *testing.T) {
+	session, conn, _ := setupTestSession(t)
+	session.identityRes = func(recipient string) (string, error) {
+		return "role_testrole@example.com.db", nil
+	}
+
+	conn.writeString("LHLO client.example.com\r\n")
+	conn.writeString("MAIL FROM:<sender@example.com>\r\n")
+	conn.writeString("RCPT TO:<testrole@example.com>\r\n")
+	conn.writeString("QUIT\r\n")
+
+	_ = session.Handle()
+
+	if len(session.recipients) != 1 {
+		t.Fatalf("Expected 1 recipient, got %d", len(session.recipients))
+	}
+
+	if got := session.recipients[0]; got != "testrole@example.com" {
+		t.Fatalf("Expected envelope recipient testrole@example.com, got %s", got)
+	}
+
+	if got := session.recipientMap["testrole@example.com"]; got != "role_testrole@example.com.db" {
+		t.Fatalf("Expected resolved identity role_testrole@example.com.db, got %s", got)
+	}
+}
+
+func TestSession_HandleDATA_DeliversToResolvedIdentity(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "lmtp_resolved_identity_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	dbManager, err := db.NewDBManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create DB manager: %v", err)
+	}
+	defer func() { _ = dbManager.Close() }()
+
+	stor := storage.NewStorage(dbManager)
+	cfg := config.DefaultConfig()
+	cfg.LMTP.Hostname = "test.example.com"
+	cfg.LMTP.MaxSize = 1024 * 1024
+	cfg.LMTP.Timeout = 5
+	cfg.Delivery.DefaultFolder = "INBOX"
+
+	conn := newMockConn()
+	session := NewSession(conn, stor, cfg, nil)
+	session.identityRes = func(recipient string) (string, error) {
+		if recipient == "testrole@example.com" {
+			return "role_testrole@example.com.db", nil
+		}
+		return recipient, nil
+	}
+
+	conn.writeString("LHLO client.example.com\r\n")
+	conn.writeString("MAIL FROM:<sender@example.com>\r\n")
+	conn.writeString("RCPT TO:<testrole@example.com>\r\n")
+	conn.writeString("DATA\r\n")
+	conn.writeString("From: sender@example.com\r\n")
+	conn.writeString("To: testrole@example.com\r\n")
+	conn.writeString("Subject: Role delivery\r\n")
+	conn.writeString("\r\n")
+	conn.writeString("hello role\r\n")
+	conn.writeString(".\r\n")
+	conn.writeString("QUIT\r\n")
+
+	_ = session.Handle()
+
+	roleDBPath := filepath.Join(tmpDir, "role_testrole@example.com.db")
+	if _, err := os.Stat(roleDBPath); err != nil {
+		t.Fatalf("Expected role database file to exist at %s: %v", roleDBPath, err)
+	}
+
+	written := conn.getWritten()
+	if !strings.Contains(written, "Message accepted for delivery to <testrole@example.com>") {
+		t.Fatalf("Expected LMTP response to reference envelope recipient, got: %s", written)
 	}
 }
 

--- a/internal/delivery/lmtp/session_test.go
+++ b/internal/delivery/lmtp/session_test.go
@@ -393,9 +393,9 @@ func TestSession_HandleRCPT(t *testing.T) {
 
 func TestSession_HandleRCPT_StoresResolvedMailboxIdentity(t *testing.T) {
 	session, conn, _ := setupTestSession(t)
-	session.identityRes = func(recipient string) (string, error) {
+	session.identityRes = identityResolverFunc(func(recipient string) (string, error) {
 		return "role_testrole@example.com.db", nil
-	}
+	})
 
 	conn.writeString("LHLO client.example.com\r\n")
 	conn.writeString("MAIL FROM:<sender@example.com>\r\n")
@@ -439,12 +439,12 @@ func TestSession_HandleDATA_DeliversToResolvedIdentity(t *testing.T) {
 
 	conn := newMockConn()
 	session := NewSession(conn, stor, cfg, nil)
-	session.identityRes = func(recipient string) (string, error) {
+	session.identityRes = identityResolverFunc(func(recipient string) (string, error) {
 		if recipient == "testrole@example.com" {
 			return "role_testrole@example.com.db", nil
 		}
 		return recipient, nil
-	}
+	})
 
 	conn.writeString("LHLO client.example.com\r\n")
 	conn.writeString("MAIL FROM:<sender@example.com>\r\n")
@@ -468,6 +468,65 @@ func TestSession_HandleDATA_DeliversToResolvedIdentity(t *testing.T) {
 	written := conn.getWritten()
 	if !strings.Contains(written, "Message accepted for delivery to <testrole@example.com>") {
 		t.Fatalf("Expected LMTP response to reference envelope recipient, got: %s", written)
+	}
+}
+
+func TestSession_HandleDATA_DeduplicatesMappedRecipients(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "lmtp_dedup_identity_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	dbManager, err := db.NewDBManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create DB manager: %v", err)
+	}
+	defer func() { _ = dbManager.Close() }()
+
+	stor := storage.NewStorage(dbManager)
+	cfg := config.DefaultConfig()
+	cfg.LMTP.Hostname = "test.example.com"
+	cfg.LMTP.MaxSize = 1024 * 1024
+	cfg.LMTP.Timeout = 5
+	cfg.Delivery.DefaultFolder = "INBOX"
+
+	conn := newMockConn()
+	session := NewSession(conn, stor, cfg, nil)
+	session.identityRes = identityResolverFunc(func(recipient string) (string, error) {
+		if recipient == "team-alias@example.com" || recipient == "team-role@example.com" {
+			return "role_team@example.com.db", nil
+		}
+		return recipient, nil
+	})
+
+	conn.writeString("LHLO client.example.com\r\n")
+	conn.writeString("MAIL FROM:<sender@example.com>\r\n")
+	conn.writeString("RCPT TO:<team-alias@example.com>\r\n")
+	conn.writeString("RCPT TO:<team-role@example.com>\r\n")
+	conn.writeString("DATA\r\n")
+	conn.writeString("From: sender@example.com\r\n")
+	conn.writeString("To: team-alias@example.com, team-role@example.com\r\n")
+	conn.writeString("Subject: Dedup delivery\r\n")
+	conn.writeString("\r\n")
+	conn.writeString("hello team\r\n")
+	conn.writeString(".\r\n")
+	conn.writeString("QUIT\r\n")
+
+	_ = session.Handle()
+
+	roleDB, err := dbManager.GetUserDB("role_team@example.com.db")
+	if err != nil {
+		t.Fatalf("Failed to open role database: %v", err)
+	}
+
+	var messageCount int
+	if err := roleDB.QueryRow("SELECT COUNT(*) FROM messages").Scan(&messageCount); err != nil {
+		t.Fatalf("Failed to query messages count: %v", err)
+	}
+
+	if messageCount != 1 {
+		t.Fatalf("Expected exactly 1 message after deduped delivery, got %d", messageCount)
 	}
 }
 

--- a/internal/delivery/lmtp/socketmap.go
+++ b/internal/delivery/lmtp/socketmap.go
@@ -1,0 +1,66 @@
+package lmtp
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"raven/internal/delivery/config"
+	"raven/internal/socketmap/protocol"
+)
+
+// identityResolver resolves recipient address to mailbox identity.
+type identityResolver func(recipient string) (string, error)
+
+func newIdentityResolver(cfg *config.Config) identityResolver {
+	if cfg == nil || !cfg.Socketmap.Enabled {
+		return nil
+	}
+
+	return newSocketmapIdentityResolver(cfg)
+}
+
+func newSocketmapIdentityResolver(cfg *config.Config) identityResolver {
+	network := cfg.Socketmap.Network
+	address := cfg.Socketmap.Address
+	timeout := time.Duration(cfg.Socketmap.TimeoutSeconds) * time.Second
+
+	return func(recipient string) (string, error) {
+		conn, err := net.DialTimeout(network, address, timeout)
+		if err != nil {
+			return "", fmt.Errorf("socketmap dial failed: %w", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		_ = conn.SetDeadline(time.Now().Add(timeout))
+
+		if err := protocol.WriteNetstring(conn, fmt.Sprintf("user-exists %s", recipient)); err != nil {
+			return "", fmt.Errorf("socketmap write failed: %w", err)
+		}
+
+		resp, err := protocol.ReadNetstring(bufio.NewReader(conn))
+		if err != nil {
+			return "", fmt.Errorf("socketmap read failed: %w", err)
+		}
+
+		if strings.HasPrefix(resp, "OK ") {
+			parts := strings.Fields(resp)
+			if len(parts) >= 2 {
+				return parts[1], nil
+			}
+			return recipient, nil
+		}
+
+		if resp == "NOTFOUND" {
+			return recipient, nil
+		}
+
+		if strings.HasPrefix(resp, "PERM") || strings.HasPrefix(resp, "TEMP") {
+			return "", fmt.Errorf("socketmap returned %q", resp)
+		}
+
+		return recipient, nil
+	}
+}

--- a/internal/delivery/lmtp/socketmap.go
+++ b/internal/delivery/lmtp/socketmap.go
@@ -12,7 +12,20 @@ import (
 )
 
 // identityResolver resolves recipient address to mailbox identity.
-type identityResolver func(recipient string) (string, error)
+type identityResolver interface {
+	Resolve(recipient string) (string, error)
+	Close() error
+}
+
+type identityResolverFunc func(recipient string) (string, error)
+
+func (f identityResolverFunc) Resolve(recipient string) (string, error) {
+	return f(recipient)
+}
+
+func (f identityResolverFunc) Close() error {
+	return nil
+}
 
 func newIdentityResolver(cfg *config.Config) identityResolver {
 	if cfg == nil || !cfg.Socketmap.Enabled {
@@ -22,45 +35,96 @@ func newIdentityResolver(cfg *config.Config) identityResolver {
 	return newSocketmapIdentityResolver(cfg)
 }
 
+type socketmapIdentityResolver struct {
+	network string
+	address string
+	timeout time.Duration
+	conn    net.Conn
+	reader  *bufio.Reader
+}
+
 func newSocketmapIdentityResolver(cfg *config.Config) identityResolver {
-	network := cfg.Socketmap.Network
-	address := cfg.Socketmap.Address
-	timeout := time.Duration(cfg.Socketmap.TimeoutSeconds) * time.Second
+	return &socketmapIdentityResolver{
+		network: cfg.Socketmap.Network,
+		address: cfg.Socketmap.Address,
+		timeout: time.Duration(cfg.Socketmap.TimeoutSeconds) * time.Second,
+	}
+}
 
-	return func(recipient string) (string, error) {
-		conn, err := net.DialTimeout(network, address, timeout)
-		if err != nil {
-			return "", fmt.Errorf("socketmap dial failed: %w", err)
+func (r *socketmapIdentityResolver) Resolve(recipient string) (string, error) {
+	if err := r.ensureConn(); err != nil {
+		return "", err
+	}
+
+	identity, err := r.resolveWithConn(recipient)
+	if err == nil {
+		return identity, nil
+	}
+
+	// Retry once on stale/broken connection by reconnecting.
+	r.closeConn()
+	if retryErr := r.ensureConn(); retryErr != nil {
+		return "", retryErr
+	}
+
+	return r.resolveWithConn(recipient)
+}
+
+func (r *socketmapIdentityResolver) Close() error {
+	r.closeConn()
+	return nil
+}
+
+func (r *socketmapIdentityResolver) ensureConn() error {
+	if r.conn != nil {
+		return nil
+	}
+
+	conn, err := net.DialTimeout(r.network, r.address, r.timeout)
+	if err != nil {
+		return fmt.Errorf("socketmap dial failed: %w", err)
+	}
+
+	r.conn = conn
+	r.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (r *socketmapIdentityResolver) resolveWithConn(recipient string) (string, error) {
+	_ = r.conn.SetDeadline(time.Now().Add(r.timeout))
+
+	if err := protocol.WriteNetstring(r.conn, fmt.Sprintf("user-exists %s", recipient)); err != nil {
+		return "", fmt.Errorf("socketmap write failed: %w", err)
+	}
+
+	resp, err := protocol.ReadNetstring(r.reader)
+	if err != nil {
+		return "", fmt.Errorf("socketmap read failed: %w", err)
+	}
+
+	if strings.HasPrefix(resp, "OK ") {
+		parts := strings.Fields(resp)
+		if len(parts) >= 2 {
+			return parts[1], nil
 		}
-		defer func() { _ = conn.Close() }()
-
-		_ = conn.SetDeadline(time.Now().Add(timeout))
-
-		if err := protocol.WriteNetstring(conn, fmt.Sprintf("user-exists %s", recipient)); err != nil {
-			return "", fmt.Errorf("socketmap write failed: %w", err)
-		}
-
-		resp, err := protocol.ReadNetstring(bufio.NewReader(conn))
-		if err != nil {
-			return "", fmt.Errorf("socketmap read failed: %w", err)
-		}
-
-		if strings.HasPrefix(resp, "OK ") {
-			parts := strings.Fields(resp)
-			if len(parts) >= 2 {
-				return parts[1], nil
-			}
-			return recipient, nil
-		}
-
-		if resp == "NOTFOUND" {
-			return recipient, nil
-		}
-
-		if strings.HasPrefix(resp, "PERM") || strings.HasPrefix(resp, "TEMP") {
-			return "", fmt.Errorf("socketmap returned %q", resp)
-		}
-
 		return recipient, nil
 	}
+
+	if resp == "NOTFOUND" {
+		return recipient, nil
+	}
+
+	if strings.HasPrefix(resp, "PERM") || strings.HasPrefix(resp, "TEMP") {
+		return "", fmt.Errorf("socketmap returned %q", resp)
+	}
+
+	return recipient, nil
+}
+
+func (r *socketmapIdentityResolver) closeConn() {
+	if r.conn != nil {
+		_ = r.conn.Close()
+	}
+	r.conn = nil
+	r.reader = nil
 }

--- a/internal/socketmap/handler/user.go
+++ b/internal/socketmap/handler/user.go
@@ -11,27 +11,30 @@ import (
 	"raven/internal/socketmap/thunder"
 )
 
-// UserExists checks if a user exists in Thunder IDP
-func UserExists(email string, cfg *config.Config, cacheManager *cache.Cache) bool {
+// ResolveMailboxIdentity validates an address and returns the mailbox identity path.
+func ResolveMailboxIdentity(email string, cfg *config.Config, cacheManager *cache.Cache) (bool, string) {
 	log.Printf("    ┌─ User Lookup ───────────────────")
 	log.Printf("    │ Email: %s", email)
-	
+
 	// Check cache first (read lock)
 	cacheKey := "user:" + email
 	entry, found := cacheManager.Get(cacheKey)
-	
+
 	now := time.Now()
-	
+
 	if found {
 		// Cache hit - check if still valid
 		if !cacheManager.IsExpired(entry) {
 			log.Printf("    │ ✓ CACHE HIT (fresh)")
 			log.Printf("    │ Cached result: exists=%v", entry.Exists)
+			if entry.Data != "" {
+				log.Printf("    │ Cached mailbox identity: %s", entry.Data)
+			}
 			log.Printf("    │ Expires: %s", entry.Expires.Format("15:04:05"))
 			log.Printf("    └─────────────────────────────────")
-			return entry.Exists
+			return entry.Exists, entry.Data
 		}
-		
+
 		// Cache expired - check if we should refresh
 		cacheAge := now.Sub(entry.LastUpdate).Seconds()
 		log.Printf("    │ ✓ CACHE HIT (stale)")
@@ -41,6 +44,8 @@ func UserExists(email string, cfg *config.Config, cacheManager *cache.Cache) boo
 		log.Printf("    │ ✗ CACHE MISS")
 		log.Printf("    │ Querying IDP...")
 	}
+
+	mailboxIdentity := email
 
 	// Query Thunder IDP for user validation first.
 	exists, err := thunder.ValidateUser(email, cfg.ThunderHost, cfg.ThunderPort, cfg.TokenRefreshSeconds)
@@ -60,16 +65,29 @@ func UserExists(email string, cfg *config.Config, cacheManager *cache.Cache) boo
 		}
 	}
 
+	// Validate role-based mailbox addresses (e.g., admin@domain).
+	if !exists && strings.Contains(email, "@") {
+		roleExists, roleMailboxIdentity, roleErr := thunder.ValidateRoleAddress(email, cfg.ThunderHost, cfg.ThunderPort, cfg.TokenRefreshSeconds)
+		if roleErr != nil {
+			log.Printf("    │ ⚠ Role lookup failed: %v", roleErr)
+		} else if roleExists {
+			log.Printf("    │ ✓ Role found; treating as existing user")
+			exists = true
+			mailboxIdentity = roleMailboxIdentity
+		}
+	}
+
 	if !exists {
-		log.Printf("    │ User/group not found - Thunder unavailable or no match")
+		log.Printf("    │ User/group/role not found - Thunder unavailable or no match")
 	}
 
 	log.Printf("    │ IDP result: exists=%v", exists)
-	
+
 	// Only cache positive results (exists=true)
 	if exists {
 		cacheManager.Set(cacheKey, cache.Entry{
 			Exists:     true,
+			Data:       mailboxIdentity,
 			Expires:    now.Add(cacheManager.GetTTL()),
 			LastUpdate: now,
 		})
@@ -77,21 +95,33 @@ func UserExists(email string, cfg *config.Config, cacheManager *cache.Cache) boo
 	} else {
 		log.Printf("    │ ℹ Negative result NOT cached (will query IDP next time)")
 	}
-	
+
 	log.Printf("    └─────────────────────────────────")
 
+	if exists {
+		return true, mailboxIdentity
+	}
+
+	return false, ""
+}
+
+// UserExists checks if a user, group, or role mailbox exists in Thunder IDP.
+func UserExists(email string, cfg *config.Config, cacheManager *cache.Cache) bool {
+	exists, _ := ResolveMailboxIdentity(email, cfg, cacheManager)
 	return exists
 }
 
 // HandleUserExistsMap handles the user-exists map lookup
 func HandleUserExistsMap(key string, cfg *config.Config, cacheManager *cache.Cache) string {
 	log.Printf("  │ Checking if user exists...")
-	exists := UserExists(key, cfg, cacheManager)
+	exists, mailboxPath := ResolveMailboxIdentity(key, cfg, cacheManager)
 
 	if exists {
 		// For virtual_mailbox_maps, Postfix expects a mailbox pathname
-		mailboxPath := key
-		
+		if mailboxPath == "" {
+			mailboxPath = key
+		}
+
 		log.Printf("  │ ✓ USER FOUND: %s", key)
 		log.Printf("  │ Response: OK %s", mailboxPath)
 		log.Printf("  └─────────────────────────────────────")

--- a/internal/socketmap/thunder/role.go
+++ b/internal/socketmap/thunder/role.go
@@ -1,0 +1,110 @@
+package thunder
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// ValidateRoleAddress checks whether an email local-part matches a role in the same OU as the domain.
+// If it matches, it returns a mailbox identity in role_<role-name>@<domain>.db format.
+func ValidateRoleAddress(email, host, port string, tokenRefreshSeconds int) (bool, string, error) {
+	log.Printf("      ┌─ Thunder Role Validation ─────")
+	log.Printf("      │ Email: %s", email)
+	defer log.Printf("      └──────────────────────────────")
+
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		log.Printf("      │ ✗ Invalid email format")
+		return false, "", nil
+	}
+
+	roleName := strings.TrimSpace(parts[0])
+	domain := strings.TrimSpace(parts[1])
+	if roleName == "" || domain == "" {
+		log.Printf("      │ ✗ Empty role or domain")
+		return false, "", nil
+	}
+
+	log.Printf("      │ Role candidate: %s", roleName)
+	log.Printf("      │ Domain: %s", domain)
+
+	auth, err := GetAuth(host, port, tokenRefreshSeconds)
+	if err != nil {
+		log.Printf("      │ ⚠ Auth failed: %v", err)
+		return false, "", err
+	}
+
+	ouID, err := GetOrgUnitIDForDomain(domain, host, port, tokenRefreshSeconds)
+	if err != nil {
+		log.Printf("      │ ⚠ Failed to get OU ID: %v", err)
+		return false, "", err
+	}
+	log.Printf("      │ OU ID: %s", ouID)
+
+	client := GetHTTPClient()
+	pageStartIndex := 1
+	pageSize := 100
+
+	for {
+		baseURL := fmt.Sprintf("https://%s:%s/roles", host, port)
+		req, err := http.NewRequest("GET", baseURL, nil)
+		if err != nil {
+			log.Printf("      │ ✗ Failed to create request: %v", err)
+			return false, "", err
+		}
+
+		q := req.URL.Query()
+		q.Set("startIndex", fmt.Sprintf("%d", pageStartIndex))
+		q.Set("count", fmt.Sprintf("%d", pageSize))
+		req.URL.RawQuery = q.Encode()
+
+		req.Header.Set("Authorization", "Bearer "+auth.BearerToken)
+		req.Header.Set("Content-Type", "application/json")
+
+		log.Printf("      │ Query: %s", req.URL.String())
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("      │ ✗ Request failed: %v", err)
+			return false, "", err
+		}
+
+		var rolesResp RolesResponse
+		decodeErr := json.NewDecoder(resp.Body).Decode(&rolesResp)
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			log.Printf("      │ ⚠ Failed to close role response body: %v", closeErr)
+		}
+
+		if resp.StatusCode != 200 {
+			log.Printf("      │ ⚠ Unexpected status: %d", resp.StatusCode)
+			return false, "", fmt.Errorf("unexpected status: %d", resp.StatusCode)
+		}
+		if decodeErr != nil {
+			log.Printf("      │ ✗ Failed to parse response: %v", decodeErr)
+			return false, "", decodeErr
+		}
+
+		log.Printf("      │ Page start: %d, count: %d, total: %d", rolesResp.StartIndex, rolesResp.Count, rolesResp.TotalResults)
+
+		for _, role := range rolesResp.Roles {
+			if role.OrganizationUnitID == ouID && strings.EqualFold(role.Name, roleName) {
+				mailboxIdentity := fmt.Sprintf("role_%s@%s.db", strings.ToLower(roleName), strings.ToLower(domain))
+				log.Printf("      │ ✓ Role found and OU matches")
+				log.Printf("      │ Mailbox identity: %s", mailboxIdentity)
+				return true, mailboxIdentity, nil
+			}
+		}
+
+		if rolesResp.Count <= 0 || rolesResp.StartIndex+rolesResp.Count > rolesResp.TotalResults {
+			break
+		}
+		pageStartIndex = rolesResp.StartIndex + rolesResp.Count
+	}
+
+	log.Printf("      │ ✗ Role not found for OU/domain")
+	return false, "", nil
+}

--- a/internal/socketmap/thunder/types.go
+++ b/internal/socketmap/thunder/types.go
@@ -6,7 +6,7 @@ import (
 
 // Auth holds Thunder authentication state
 type Auth struct {
-	DevelopAppID  string
+	DevelopAppID string
 	FlowID       string
 	BearerToken  string
 	ExpiresAt    time.Time
@@ -34,10 +34,10 @@ type OrgUnitResponse struct {
 
 // UsersResponse represents the response from Thunder Users API
 type UsersResponse struct {
-	TotalResults int          `json:"totalResults"`
-	StartIndex   int          `json:"startIndex"`
-	Count        int          `json:"count"`
-	Users        []User       `json:"users"`
+	TotalResults int           `json:"totalResults"`
+	StartIndex   int           `json:"startIndex"`
+	Count        int           `json:"count"`
+	Users        []User        `json:"users"`
 	Links        []interface{} `json:"links"`
 }
 
@@ -60,6 +60,22 @@ type GroupsResponse struct {
 
 // Group represents a Thunder group
 type Group struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	OrganizationUnitID string `json:"ouId"`
+}
+
+// RolesResponse represents the response from Thunder Roles API.
+type RolesResponse struct {
+	TotalResults int           `json:"totalResults"`
+	StartIndex   int           `json:"startIndex"`
+	Count        int           `json:"count"`
+	Roles        []Role        `json:"roles"`
+	Links        []interface{} `json:"links"`
+}
+
+// Role represents a Thunder role.
+type Role struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
 	OrganizationUnitID string `json:"ouId"`


### PR DESCRIPTION
## 📌 Description
Now, the socketmap service will check role-based emails in the `user-exists` check. When LMTP transfers the email to the raven, it checks whether that mail is role-based mail or user-defined mail, based on that it saved in relavant database with the correct prefix. ex: `user_` or `role_`
<!-- Provide a clear, concise description of what this PR does. -->

- Closes #271 

---

## 🔍 Changes Made
- user-exists in sockermap accept role-based email addresses
- LMTP service checks whether the email address is role-based or user-based email, always hitting the cache.
<!-- List key changes in bullet points. -->

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

<!-- Explain how reviewers can test your changes. -->

To test the server, use the instructions in the [README](https://github.com/LSFLK/raven/blob/main/test/README.md) in the `test` directory.

---

## 📷 Screenshots / Logs (if applicable)

<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
Need to create a role in the thunder ui and send an email to that role's email address.
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
