### PR TITLE
feat: update extractAllHeaders func to only use the header section for header extraction

### DIFF
--- a/internal/delivery/parser/parser.go
+++ b/internal/delivery/parser/parser.go
@@ -1181,8 +1181,14 @@ func ReadDataCommand(r *bufio.Reader, maxSize int64) ([]byte, error) {
 // multi-line continuations. Only lines starting with space/tab extend the previous header,
 // preventing malformed headers from corrupting adjacent fields.
 func extractAllHeaders(rawMessage string) []MessageHeader {
+	rawHeaderMessage := strings.Clone(rawMessage);
+	if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd > 0 {
+		rawHeaderMessage = rawHeaderMessage[:headerEnd]
+	} else if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd > 0 {
+		rawHeaderMessage = rawHeaderMessage[:headerEnd]
+	}
 	var headers []MessageHeader
-	lines := strings.Split(rawMessage, "\n")
+	lines := strings.Split(rawHeaderMessage, "\n")
 	sequence := 0
 	var currentHeaderName string
 	var currentHeaderValue strings.Builder

--- a/internal/delivery/parser/parser.go
+++ b/internal/delivery/parser/parser.go
@@ -1181,12 +1181,12 @@ func ReadDataCommand(r *bufio.Reader, maxSize int64) ([]byte, error) {
 // multi-line continuations. Only lines starting with space/tab extend the previous header,
 // preventing malformed headers from corrupting adjacent fields.
 func extractAllHeaders(rawMessage string) []MessageHeader {
-	rawHeaderMessage := strings.Clone(rawMessage);
-	if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd > 0 {
-		rawHeaderMessage = rawHeaderMessage[:headerEnd]
-	} else if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd > 0 {
-		rawHeaderMessage = rawHeaderMessage[:headerEnd]
-	}
+rawHeaderMessage := rawMessage
+if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd >= 0 {
+	rawHeaderMessage = rawMessage[:headerEnd]
+} else if headerEnd := strings.Index(rawMessage, "\n\n"); headerEnd >= 0 {
+	rawHeaderMessage = rawMessage[:headerEnd]
+}
 	var headers []MessageHeader
 	lines := strings.Split(rawHeaderMessage, "\n")
 	sequence := 0

--- a/internal/delivery/parser/parser.go
+++ b/internal/delivery/parser/parser.go
@@ -1181,12 +1181,12 @@ func ReadDataCommand(r *bufio.Reader, maxSize int64) ([]byte, error) {
 // multi-line continuations. Only lines starting with space/tab extend the previous header,
 // preventing malformed headers from corrupting adjacent fields.
 func extractAllHeaders(rawMessage string) []MessageHeader {
-rawHeaderMessage := rawMessage
-if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd >= 0 {
-	rawHeaderMessage = rawMessage[:headerEnd]
-} else if headerEnd := strings.Index(rawMessage, "\n\n"); headerEnd >= 0 {
-	rawHeaderMessage = rawMessage[:headerEnd]
-}
+	rawHeaderMessage := rawMessage
+	if headerEnd := strings.Index(rawMessage, "\r\n\r\n"); headerEnd >= 0 {
+		rawHeaderMessage = rawMessage[:headerEnd]
+	} else if headerEnd := strings.Index(rawMessage, "\n\n"); headerEnd >= 0 {
+		rawHeaderMessage = rawMessage[:headerEnd]
+	}
 	var headers []MessageHeader
 	lines := strings.Split(rawHeaderMessage, "\n")
 	sequence := 0

--- a/internal/delivery/parser/parser.go
+++ b/internal/delivery/parser/parser.go
@@ -1198,14 +1198,6 @@ func extractAllHeaders(rawMessage string) []MessageHeader {
 
 		// Empty line marks end of headers section
 		if line == "" {
-			// Save last header if exists
-			if currentHeaderName != "" {
-				headers = append(headers, MessageHeader{
-					Name:     currentHeaderName,
-					Value:    currentHeaderValue.String(),
-					Sequence: sequence,
-				})
-			}
 			break
 		}
 
@@ -1241,6 +1233,14 @@ func extractAllHeaders(rawMessage string) []MessageHeader {
 		// Parse new header field
 		currentHeaderName = strings.TrimSpace(line[:colonIdx])
 		currentHeaderValue.WriteString(strings.TrimSpace(line[colonIdx+1:]))
+	}
+
+	if currentHeaderName != "" {
+		headers = append(headers, MessageHeader{
+			Name:     currentHeaderName,
+			Value:    currentHeaderValue.String(),
+			Sequence: sequence,
+		})
 	}
 
 	return headers

--- a/internal/delivery/parser/parser_test.go
+++ b/internal/delivery/parser/parser_test.go
@@ -589,6 +589,77 @@ Body starts here.`
 	}
 }
 
+func TestExtractAllHeadersExcludesBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawMessage string
+	}{
+		{
+			name: "CRLF separator",
+			rawMessage: "From: sender@example.com\r\n" +
+				"To: recipient@example.com\r\n" +
+				"Subject: Test Subject\r\n" +
+				"\r\n" +
+				"This is the body.\r\n" +
+				"X-Injected: evil\r\n" +
+				"More body text.\r\n",
+		},
+		{
+			name: "LF separator",
+			rawMessage: "From: sender@example.com\n" +
+				"To: recipient@example.com\n" +
+				"Subject: Test Subject\n" +
+				"\n" +
+				"This is the body.\n" +
+				"X-Injected: evil\n" +
+				"More body text.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := parser.ParseMIMEMessage(tt.rawMessage)
+			if err != nil {
+				t.Fatalf("Failed to parse message: %v", err)
+			}
+
+			foundSubject := false
+			for _, header := range msg.Headers {
+				if header.Name == "X-Injected" {
+					t.Errorf("Expected no X-Injected header from body, got %q", header.Value)
+				}
+				if header.Name == "Subject" {
+					foundSubject = true
+				}
+			}
+
+			if !foundSubject {
+				t.Error("Expected Subject header to be extracted from the header section")
+			}
+		})
+	}
+}
+
+func TestExtractAllHeadersStopsAtFirstBlankLine(t *testing.T) {
+	rawMessage := "From: sender@example.com\r\n" +
+		"To: recipient@example.com\n" +
+		"\n" +
+		"X-Injected: evil\r\n" +
+		"\r\n" +
+		"Body text.\r\n"
+
+	msg, err := parser.ParseMIMEMessage(rawMessage)
+	if err != nil {
+		t.Fatalf("Failed to parse message: %v", err)
+	}
+
+	for _, header := range msg.Headers {
+		if header.Name == "X-Injected" {
+			t.Errorf("Expected no X-Injected header from body, got %q", header.Value)
+		}
+	}
+}
+
 func TestIsValidEmail(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Description

Updated the Function `extractAllHeaders` within `internal/delivery/parser/parser.go`, to first split the rawMessage utilizing double new lines and trying to find the headers within that section instead of going through the entire email message.

- Closes #279 

Verified through `make test`
